### PR TITLE
RGRIDT-633: Fix Dropdown symbol (CSS)

### DIFF
--- a/code/styles/Grid.css
+++ b/code/styles/Grid.css
@@ -138,10 +138,18 @@
     padding: 14px 8px 0px 8px;
 }
 
-.wj-flexgrid .wj-grid-editor {
-    height: auto;
+.wj-flexgrid .wj-grid-editor,
+.wj-flexgrid .wj-cell.wj-hasdropdown .wj-btn.wj-btn-glyph.wj-right {
+    height: auto; 
 }
 
+.wj-flexgrid .wj-cell.wj-hasdropdown input{
+  width: 80%;
+}
+
+.wj-flexgrid .wj-cell.wj-hasdropdown .wj-dropdown.wj-inputdate input{
+  width: 100%;
+}
 .wj-colheaders > .wj-row > .wj-cell::before,
 .wj-flexgrid .wj-colheaders .wj-header.wj-colgroup.wj-cell::before {
     content: '';


### PR DESCRIPTION
This PR is for RGRIDT-633 - Dropdown symbol is over the text from the input on dropdown columns.

### What was happening
* As you can see the dropdown symbol 🔽 is moving down and is also over the text that is displayed on the input from the cell.
![image](https://user-images.githubusercontent.com/6432232/108227136-7bd9aa80-7135-11eb-8efe-d0e28d79c4a2.png)

### What was done
* As a solution, I changed the CSS configuration for the button (parent of the dropdown symbol) to have an auto height. 
* As for the symbol that is over the text, I believe our best option here is to set the width of the input to 80%. 

### Test Steps
1. Open the dropdown (click on the symbol on a cell from a dropdown column)
Expected: The cell should open for edit mode and a dropdown with multiple options for that cell should appear. Regarding the style, the cell should display a symbol 🔽 at the right side of the input and nothing else should happen to the style. (You might notice that the symbol gets a higher opacity, that's a normal and expected behavior of hovering the symbol)


### Screenshots
Before the fix:
![dropdown symbol bug](https://user-images.githubusercontent.com/6432232/108228139-7c267580-7136-11eb-965a-2af9b270f684.gif)

After the fix:
![dropdown symbol](https://user-images.githubusercontent.com/6432232/108228150-7df03900-7136-11eb-872c-3b6edecf1bd9.gif)

### Checklist
* [x] tested locally
* [ ] documented the code **(NA)**
* [ ] clean all warnings and errors of eslint **(NA)**
* [ ] requires changes in OutSystems (if so, provide a module with changes) **(NA)**
* [ ] requires new sample page in OutSystems (if so, provide a module with changes) **(NA)**

