### PR TITLE
RGRIDT-591: Clear Dirty Mark (clearProperty method) was only considering the current page

### DIFF
--- a/code/src/Grid/RowMetadata.ts
+++ b/code/src/Grid/RowMetadata.ts
@@ -55,6 +55,7 @@ namespace Grid {
         }
 
         public clearProperty(propertyName: string): void {
+            // Iterate all rows from the grid using the sourceCollection (not just the rows from the current page - items)
             this._itemsSource.sourceCollection.forEach((p) => {
                 p[this._extraData] &&
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This PR is for RGRIDT-591: Save Changes - only affecting current page

### What was happening
* It seems that the MarkChangesAsSaved method was actually getting all data saved. The problem wasn’t directly affecting the logic of the method but the visual part instead. After marking all changes as saved, we need to remove the dirty mark from all dataItems. The problem lies here.
If you inspect the `_itemsSource.items` during run time, in this case, you will find that the items are actually returning the rows that are currently on the view. 


### What was done
* We might want to review this, but changing ~~items~~ ❌ to sourceCollection ✔ we fix the problem.
What this will do, is basically delete from the whole set of rows (dataItems) the metadata →  {"__dirtyMarkFeature" => DirtyMarksInfo}.


### Test Steps 
(Make sure the sample has more than 1 page)
1. Open Page
2. Set page of the grid to 1.
3. Change the content of column Product Name and a dirty mark will appear
4. Set page of the grid to 3. 
5.Change the content of column Product Name and a dirty mark will appear
6.Press "Mark Changes As Saved" button


### Screenshots
**Before fix:**
![ccf40d09-6c88-4bb2-af1e-26aabae11494](https://user-images.githubusercontent.com/6432232/108337753-5dbf8900-71cd-11eb-9ec1-6ba4f7532eea.gif)

**After fix:**
![saveChanges](https://user-images.githubusercontent.com/6432232/108337895-8c3d6400-71cd-11eb-9b8b-64a34b206f54.gif)


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes) **(NA)**
* [ ] requires new sample page in OutSystems (if so, provide a module with changes) **(NA)**
