### PR TITLE
Improving the mechanism for loading the locale resource

### DIFF
--- a/code/src/Helpers/Translation.ts
+++ b/code/src/Helpers/Translation.ts
@@ -1,28 +1,51 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Helper {
+    function transposeLanguageFormat(language: string): string {
+        let changedLang = language;
+
+        switch (language) {
+            //the following languages exist in these variants
+            case 'ar-AE':
+            case 'de-CH':
+            case 'en-CA':
+            case 'de-GB':
+            case 'mn-MN':
+            case 'zh-HK':
+            case 'zh-TW':
+                break;
+            //all other languages, the provider doesn't have a local variant
+            default:
+                changedLang = language.substring(0, 2);
+        }
+
+        return changedLang;
+    }
+
     export function SetLanguage(language: string, url: string): void {
         const regex = new RegExp('(?<=culture.)(.*)(?=.min)');
-        url = url.replace(regex, language);
+        const transposedLanguage = transposeLanguageFormat(language);
+        url = url.replace(regex, transposedLanguage);
 
-        fetch(url).then(function (response) {
-            if (!response.ok) {
-                url = url.replace(regex, language.substring(0, 2));
+        fetch(url, { method: 'HEAD' }).then(function (response) {
+            if (response.ok) {
+                // this callback is wijmo's workaround to translate the group panel. Remove once they've fixed
+                DynamicallyLoadScript(url, function () {
+                    const gps = document.body.querySelectorAll(
+                        '.wj-control.wj-grouppanel'
+                    );
+                    const culture = wijmo.culture;
+                    for (let i = 0; i < gps.length; i++) {
+                        const gp = wijmo.Control.getControl(gps[i]);
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore
+                        gp.placeholder = culture.GroupPanel.dragDrop;
+                    }
+                    wijmo.Control.invalidateAll();
+                });
+            } else {
+                //if the language resource is not found in the server, then throw an error and let the english be the default language.
+                throw `The language "${language}" is not supported. Falling back to "en-US" language.`;
             }
-
-            // this callback is wijmo's workaround to translate the group panel. Remove once they've fixed
-            DynamicallyLoadScript(url, function () {
-                const gps = document.body.querySelectorAll(
-                    '.wj-control.wj-grouppanel'
-                );
-                const culture = wijmo.culture;
-                for (let i = 0; i < gps.length; i++) {
-                    const gp = wijmo.Control.getControl(gps[i]);
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore
-                    gp.placeholder = culture.GroupPanel.dragDrop;
-                }
-                wijmo.Control.invalidateAll();
-            });
         });
     }
 }


### PR DESCRIPTION
This PR is for avoiding a 404 requests when language resources are not found.

### What was happening
* The provider of the grid, doesn't follow RFC 1766 format, and for the majority of supported languages, only has the language code (e.g. "en" instead of the RFC 1766 format "en-US")
* The platform uses RFC 1766 format for all languages - default is "" (empty string).
* This caused an unnecessary 404 responses.

### What was done
* A new private function to transpose from RFC 1766, to the providers format was created.
* In the case a language resource is not found in the server an exception is being now trowed by the code.