### PR TITLE
Hotfix RGRIDT-657 - Converting date to OS-Date format

### DIFF
--- a/code/src/Grid/FlexGrid.ts
+++ b/code/src/Grid/FlexGrid.ts
@@ -43,9 +43,6 @@ namespace Grid {
                 delete tempArray[tempArray.length - 1].__osRowMetada;
             }
 
-            //TODO: [RGRIDT-665] Improve _getChangesString
-            //The code: should use our API delete tempArray[tempArray.length - 1].__osRowMetada;
-            //The code: tempArray.push(_.clone(itemsChanged[index])); is maintaining a reference to the object on datasource
             tempArray = Helper.ToOSFormat(this, tempArray);
 
             if (this.isSingleEntity) {


### PR DESCRIPTION
### What was happening
* Flatten was running before method ToOSFormat, affecting the way the last method works

### What was done
* The order of the methods were inverted
* ToOSFormat now perform the changes in-place, avoiding a new data-clone

### Test Steps
1. Sample available on jira
2. Change the date and save it
3. Reload the page
4. Check the saved and the load date information

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

