### PR TITLE
RGRIDT-674: Menu Item IsActive: change the name to Enabled + description

### DIFF
--- a/code/src/API/ContextMenu.ts
+++ b/code/src/API/ContextMenu.ts
@@ -29,16 +29,16 @@ namespace GridAPI.ContextMenu {
     }
 
     /**
-     * Responsable for adding menu items
+     * Responsible for adding menu items
      * @param menuItemId UniqueId defined on OS side
      * @param label Label presented on menu
-     * @param isActive Flag used to enable the menu item
+     * @param enabled Flag used to enable the menu item
      * @param clickEvent Function executed by the menu item
      */
     export function AddItem(
         menuItemId: string,
         label: string,
-        isActive: boolean,
+        enabled: boolean,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         clickEvent: Callbacks.ContextMenu.OSClickEvent
     ): void {
@@ -55,7 +55,7 @@ namespace GridAPI.ContextMenu {
                         gridObj.features.contextMenu.addMenuItem(
                             menuItemId,
                             label,
-                            isActive,
+                            enabled,
                             clickEvent
                         );
                     }

--- a/code/src/Features/ContextMenu.ts
+++ b/code/src/Features/ContextMenu.ts
@@ -7,7 +7,7 @@ namespace Features {
         /** The method executed by the MenuItem  */
         public clickEvent: Callbacks.ContextMenu.OSClickEvent;
         /** Used to indicate if a menuItem can be executed */
-        public isActive: boolean;
+        public enabled: boolean;
         /** The list of sub-menu-items */
         public items: MenuItem[] = [];
         /** The label or display name on the context menu */
@@ -45,15 +45,15 @@ namespace Features {
          * Responsable for adding menu items
          * @param menuItemId UniqueId defined on OS side
          * @param label Label presented on menu
-         * @param isActive Flag used to enable the menu item
+         * @param enabled Flag used to enable the menu item
          * @param clickEvent Function executed by the menu item
          */
         addMenuItem(
             menuItemId: string,
             label: string,
-            isActive: boolean,
+            enabled: boolean,
             clickEvent: Callbacks.ContextMenu.OSClickEvent
-        );
+        ): void;
 
         /**
          * Responsable for adding a line separator on context menu
@@ -184,7 +184,7 @@ namespace Features {
          */
         private _canRaiseClickEvent(menuItemId: string): boolean {
             const menuItem = this._menuItems.get(menuItemId);
-            return menuItem && menuItem.isActive;
+            return menuItem && menuItem.enabled;
         }
 
         /**
@@ -345,13 +345,13 @@ namespace Features {
         public addMenuItem(
             menuItemId: string,
             label: string,
-            isActive: boolean,
+            enabled: boolean,
             executeCommand: Callbacks.ContextMenu.OSClickEvent
         ): void {
             const menuItem = new MenuItem(menuItemId);
 
             menuItem.label = label;
-            menuItem.isActive = isActive;
+            menuItem.enabled = enabled;
             menuItem.clickEvent = executeCommand;
 
             this._addMenuItem(menuItem);


### PR DESCRIPTION
This PR is for RGRIDT-674: Menu Item IsActive: change the name to Enabled + description

### What was happening
* Currently, MenuItems have an IsActive property. During usability tests, this was misleading and users thought that isActive = Visible. When setting IsActive = False, users thought that the item would not appear in the menu.
![image](https://user-images.githubusercontent.com/6432232/111447421-54123e00-8705-11eb-9aff-39fea29d97f8.png)
* The description of isActive doesn’t provide much information either:
Boolean literal or expression that defines if the Context Menu item is active.

### What was done
* Changed isActive to Enabled (like is used for the Button/Checkboxes).
* Changed the sample relative to this parameter as well.

### Screenshots
![image](https://user-images.githubusercontent.com/6432232/111447614-83c14600-8705-11eb-97ef-7dad1a058cfe.png)

### Checklist
* [ ] tested locally - **NA**
* [ ] documented the code - **NA**
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes) - **RGRIDT-674**
* [ ] requires new sample page in OutSystems (if so, provide a module with changes) - **NA**

