### PR TITLE
RGRIDT-727: Fix Unsubscribe method when grid doesn't exist

### DIFF
--- a/code/src/API/GridEvents.ts
+++ b/code/src/API/GridEvents.ts
@@ -67,7 +67,7 @@ namespace GridAPI.GridManager.Events {
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: Callbacks.OSGrid.Event
     ): void {
-        const grid = GetGridById(gridID);
+        const grid = GetGridById(gridID, false);
         if (grid !== undefined) {
             grid.gridEvents.removeHandler(eventName, callback);
         } else {


### PR DESCRIPTION
This PR is for RGRIDT-727: Fix Unsubscribe method when grid doesn't exist

### What was happening
* If the grid didn't exist, the unsubscribe method was triggering an error.

### What was done
* Changed the way we were getting the instance of the grid inside the unsubscribe method.

### Checklist
* [x] tested locally
* [ ] documented the code -NA
* [ ] clean all warnings and errors of eslint -NA
* [ ] requires changes in OutSystems (if so, provide a module with changes)  -NA
* [ ] requires new sample page in OutSystems (if so, provide a module with changes) -NA

