### PR TITLE
RGRIDT-709: Improving tests pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ stages:
 
     #Checkout repositories
     - checkout: self
-    - checkout: datagrid-web-tests
+    - checkout: datagrid-reactive-tests
 
     #Install dependencies
     - task: Npm@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,9 +2,9 @@
 
 resources:
   repositories:
-  - repository: datagrid-web-tests
+  - repository: datagrid-reactive-tests
     type: github
-    name: OutSystems/datagrid-web-tests
+    name: OutSystems/datagrid-reactive-tests
     endpoint: OutSystems
 
 trigger:

--- a/jobs/azure-pipelines-reactive.yml
+++ b/jobs/azure-pipelines-reactive.yml
@@ -57,7 +57,7 @@ stages:
     steps:
     #Checkout repositories
     - checkout: self
-    - checkout: datagrid-web-tests 
+    - checkout: datagrid-reactive-tests 
 
     - template: 'azure-pipelines-template.yml'
       parameters:

--- a/jobs/azure-pipelines-template.yml
+++ b/jobs/azure-pipelines-template.yml
@@ -20,7 +20,7 @@ steps:
     filePath: './outsystems-datagrid-reactive/jobs/branch.ps1'
     workingDirectory: ./outsystems-datagrid-reactive/
     arguments:
-      -branch 'RGRIDT-707'
+      -branch 'RGRIDT-709'
 
 #Ping sample test page
 - bash: |

--- a/jobs/azure-pipelines-template.yml
+++ b/jobs/azure-pipelines-template.yml
@@ -20,7 +20,7 @@ steps:
     filePath: './outsystems-datagrid-reactive/jobs/branch.ps1'
     workingDirectory: ./outsystems-datagrid-reactive/
     arguments:
-      -branch $(SourceBranchName)
+      -branch 'RGRIDT-709'
 
 #Ping sample test page
 - bash: |

--- a/jobs/azure-pipelines-template.yml
+++ b/jobs/azure-pipelines-template.yml
@@ -20,7 +20,7 @@ steps:
     filePath: './outsystems-datagrid-reactive/jobs/branch.ps1'
     workingDirectory: ./outsystems-datagrid-reactive/
     arguments:
-      -branch 'RGRIDT-709'
+      -branch $(SourceBranchName)
 
 #Ping sample test page
 - bash: |

--- a/jobs/azure-pipelines-template.yml
+++ b/jobs/azure-pipelines-template.yml
@@ -23,6 +23,7 @@ steps:
       -branch $(SourceBranchName)
 
 #Ping sample test page
+#Sets skip variable as true if sample doesnt exist.
 - bash: |
           status=$(curl -s --head -w %{http_code} $(ENV_URL)/$(branch)/ -o /dev/null)
           echo $status
@@ -32,11 +33,14 @@ steps:
             echo $(skip)
           fi
 
+#Only run task if skip is not true
 - task: npmAuthenticate@0
+  condition: ne(variables['skip'], 'true')
   displayName: 'Npm authenticate'
   inputs:
     workingFile: './datagrid-reactive-tests/.npmrc'
 
+#Only run task if skip is not true
 - task: CmdLine@2
   name: install_dep
   condition: ne(variables['skip'], 'true')
@@ -46,6 +50,7 @@ steps:
     script: 'yarn install'
   continueOnError: false
   
+#Only run task if skip is not true
 - task: NodeTool@0
   condition: ne(variables['skip'], 'true')
   displayName: 'Use Node 14.15.4'
@@ -77,6 +82,7 @@ steps:
     command: 'custom'
     customCommand: 'run saucelabs -- --user=$(SAUCE_LABS_USER) --key=$(SAUCE_LABS_KEY) --module=$(branch) "--browsers=${{ parameters.browser }}" --headless=false --environment=${{ parameters.environment }} --grid=${{ parameters.grid }}  "--cucumberOpts.tagExpression=$(features)"'
 
+#Only run task if skip is not true
 - task: Npm@1
   condition: ne(variables['skip'], 'true')
   displayName: 'Generate Report'
@@ -87,6 +93,7 @@ steps:
     command: 'custom'
     customCommand: 'run report'
 
+#Only run task if skip is not true
 - task: Npm@1
   condition: ne(variables['skip'], 'true')
   displayName: 'Convert to JUnit'
@@ -97,6 +104,7 @@ steps:
     command: 'custom'
     customCommand: 'run convertToJUnit'
 
+#Only run task if skip is not true
 - task: PublishTestResults@2
   condition: ne(variables['skip'], 'true')
   continueOnError: true
@@ -107,6 +115,7 @@ steps:
     failTaskOnFailedTests: false
     testRunTitle: 'Publish Report'
 
+#Only run task if skip is not true
 - task: PublishCucumberReport@1
   condition: ne(variables['skip'], 'true')
   inputs:

--- a/jobs/azure-pipelines-template.yml
+++ b/jobs/azure-pipelines-template.yml
@@ -14,32 +14,13 @@ parameters:
   type: string
 
 steps:
-- task: npmAuthenticate@0
-  displayName: 'Npm authenticate'
-  inputs:
-    workingFile: './datagrid-web-tests/.npmrc'
-
-- task: CmdLine@2
-  name: install_dep
-  displayName: 'Install dependencies using yarn'
-  inputs:
-    workingDirectory: './datagrid-web-tests/'
-    script: 'yarn install'
-  continueOnError: false
-  
-- task: NodeTool@0
-  displayName: 'Use Node 14.15.4'
-  inputs: 
-    versionSpec: '14.15.4'
-    checkLatest: true
-
 #Format branch name
 - task: PowerShell@2
   inputs:
     filePath: './outsystems-datagrid-reactive/jobs/branch.ps1'
     workingDirectory: ./outsystems-datagrid-reactive/
     arguments:
-      -branch $(SourceBranchName)
+      -branch 'RGRIDT-707'
 
 #Ping sample test page
 - bash: |
@@ -50,6 +31,27 @@ steps:
             echo "##vso[task.setvariable variable=skip;]true"
             echo $(skip)
           fi
+
+- task: npmAuthenticate@0
+  displayName: 'Npm authenticate'
+  inputs:
+    workingFile: './datagrid-web-tests/.npmrc'
+
+- task: CmdLine@2
+  name: install_dep
+  condition: ne(variables['skip'], 'true')
+  displayName: 'Install dependencies using yarn'
+  inputs:
+    workingDirectory: './datagrid-web-tests/'
+    script: 'yarn install'
+  continueOnError: false
+  
+- task: NodeTool@0
+  condition: ne(variables['skip'], 'true')
+  displayName: 'Use Node 14.15.4'
+  inputs: 
+    versionSpec: '14.15.4'
+    checkLatest: true
 
 #Retrieve test features
 - bash: |
@@ -76,6 +78,7 @@ steps:
     customCommand: 'run saucelabs -- --user=$(SAUCE_LABS_USER) --key=$(SAUCE_LABS_KEY) --module=$(branch) "--browsers=${{ parameters.browser }}" --headless=false --environment=${{ parameters.environment }} --grid=${{ parameters.grid }}  "--cucumberOpts.tagExpression=$(features)"'
 
 - task: Npm@1
+  condition: ne(variables['skip'], 'true')
   displayName: 'Generate Report'
   timeoutInMinutes: 3
   continueOnError: true
@@ -85,6 +88,7 @@ steps:
     customCommand: 'run report'
 
 - task: Npm@1
+  condition: ne(variables['skip'], 'true')
   displayName: 'Convert to JUnit'
   timeoutInMinutes: 3
   continueOnError: true
@@ -94,6 +98,7 @@ steps:
     customCommand: 'run convertToJUnit'
 
 - task: PublishTestResults@2
+  condition: ne(variables['skip'], 'true')
   continueOnError: true
   inputs:
     workingDir: './datagrid-web-tests'
@@ -103,6 +108,7 @@ steps:
     testRunTitle: 'Publish Report'
 
 - task: PublishCucumberReport@1
+  condition: ne(variables['skip'], 'true')
   inputs:
     jsonDir: './datagrid-web-tests/.tmp/json'
     outputPath: './datagrid-web-tests/.tmp'

--- a/jobs/azure-pipelines-template.yml
+++ b/jobs/azure-pipelines-template.yml
@@ -35,14 +35,14 @@ steps:
 - task: npmAuthenticate@0
   displayName: 'Npm authenticate'
   inputs:
-    workingFile: './datagrid-web-tests/.npmrc'
+    workingFile: './datagrid-reactive-tests/.npmrc'
 
 - task: CmdLine@2
   name: install_dep
   condition: ne(variables['skip'], 'true')
   displayName: 'Install dependencies using yarn'
   inputs:
-    workingDirectory: './datagrid-web-tests/'
+    workingDirectory: './datagrid-reactive-tests/'
     script: 'yarn install'
   continueOnError: false
   
@@ -64,7 +64,7 @@ steps:
   condition: and(succeeded(), eq(variables['features'],''), eq('${{ parameters.priority }}','all'), ne(variables['skip'], 'true'))
   displayName: 'Npm run all tests'
   inputs:
-    workingDir: './datagrid-web-tests/'
+    workingDir: './datagrid-reactive-tests/'
     command: 'custom'
     customCommand: 'run saucelabs -- --user=$(SAUCE_LABS_USER) --key=$(SAUCE_LABS_KEY) --module=$(branch) "--browsers=${{ parameters.browser }}" --headless=false --environment=${{ parameters.environment }} --grid=${{ parameters.grid }}  --cucumberOpts.tagExpression=@${{ parameters.grid }}'
 
@@ -73,7 +73,7 @@ steps:
   condition: ne(variables['features'],'')
   displayName: 'Npm run by $(features) feature(s)'
   inputs:
-    workingDir: './datagrid-web-tests'
+    workingDir: './datagrid-reactive-tests'
     command: 'custom'
     customCommand: 'run saucelabs -- --user=$(SAUCE_LABS_USER) --key=$(SAUCE_LABS_KEY) --module=$(branch) "--browsers=${{ parameters.browser }}" --headless=false --environment=${{ parameters.environment }} --grid=${{ parameters.grid }}  "--cucumberOpts.tagExpression=$(features)"'
 
@@ -83,7 +83,7 @@ steps:
   timeoutInMinutes: 3
   continueOnError: true
   inputs:
-    workingDir: './datagrid-web-tests'
+    workingDir: './datagrid-reactive-tests'
     command: 'custom'
     customCommand: 'run report'
 
@@ -93,7 +93,7 @@ steps:
   timeoutInMinutes: 3
   continueOnError: true
   inputs:
-    workingDir: './datagrid-web-tests'
+    workingDir: './datagrid-reactive-tests'
     command: 'custom'
     customCommand: 'run convertToJUnit'
 
@@ -101,7 +101,7 @@ steps:
   condition: ne(variables['skip'], 'true')
   continueOnError: true
   inputs:
-    workingDir: './datagrid-web-tests'
+    workingDir: './datagrid-reactive-tests'
     testResultsFormat: 'JUnit'
     testResultsFiles: '**/.tmp/junit/*.xml'
     failTaskOnFailedTests: false
@@ -110,8 +110,8 @@ steps:
 - task: PublishCucumberReport@1
   condition: ne(variables['skip'], 'true')
   inputs:
-    jsonDir: './datagrid-web-tests/.tmp/json'
-    outputPath: './datagrid-web-tests/.tmp'
+    jsonDir: './datagrid-reactive-tests/.tmp/json'
+    outputPath: './datagrid-reactive-tests/.tmp'
     theme: 'bootstrap'
     reportSuiteAsScenarios: true
     name: 'Cucumber Report'


### PR DESCRIPTION
This PR is for improving the tests pipeline

### What was happening
* Whenever there was no sample to test, we would install dependencies and do other unnecessary tasks.

### What was done
* Changed tasks order. Now we ping sample first, if we get 200 status, we proceed with other tasks. If we get status 404, we skip everything