### PR TITLE
Hotfix - SaveLoad Configs

### DIFF
--- a/code/src/Columns/AbstractProviderColumn.ts
+++ b/code/src/Columns/AbstractProviderColumn.ts
@@ -41,7 +41,7 @@ namespace Column {
             const providerGrid: wijmo.grid.FlexGrid = this.grid.provider;
 
             if (this.hasParentColumn) {
-                const parent = this.grid.columns.get(
+                const parent = this.grid.getColumn(
                     this.parentColumnId
                 ) as Column.IColumnGroup;
                 parent.addChild(this);
@@ -82,7 +82,7 @@ namespace Column {
             super.dispose();
 
             if (this.hasParentColumn) {
-                const parent = this.grid.columns.get(
+                const parent = this.grid.getColumn(
                     this.parentColumnId
                 ) as Column.IColumnGroup;
                 parent && parent.removeChild(this);

--- a/code/src/Features/ValidationMark.ts
+++ b/code/src/Features/ValidationMark.ts
@@ -410,7 +410,7 @@ namespace Features {
          */
         public validateRow(rowNumber: number): void {
             // Triggers the validation method per column
-            this._grid.columns.forEach((column: Column.IColumn) => {
+            this._grid.getColumns().forEach((column: Column.IColumn) => {
                 // This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
                 const currValue = this._grid.provider.getCellData(
                     rowNumber,

--- a/code/src/Features/View.ts
+++ b/code/src/Features/View.ts
@@ -23,8 +23,8 @@ namespace Features {
                 // * We build the columns based on OS configuration, than we load the configurations for the available columns
                 //   This should avoid errors like, a binding isn't present on the grid, or the developer have to remove some column (for securety maybe)
                 // * Different from the web version, new columns (inserted by the developer after the user "SaveConfig") will now appear on the grid, as rightmost columns
-                if (this._grid.columns.has(providerConfing.binding)) {
-                    const col = this._grid.columns.get(providerConfing.binding);
+                if (this._grid.hasColumn(providerConfing.binding)) {
+                    const col = this._grid.getColumn(providerConfing.binding);
                     const position = col.provider.index;
 
                     //Update the config based on columnsLayout

--- a/code/src/Grid/AbstractGrid.ts
+++ b/code/src/Grid/AbstractGrid.ts
@@ -18,7 +18,6 @@ namespace Grid {
     export interface IGrid extends IBuilder, IDisposable, ISearchById, IView {
         addedRows: InternalEvents.AddNewRowEvent;
         autoGenerate: boolean;
-        columns: Map<string, Column.IColumn>; //Column.IColumn[];
         config: IConfigurationGrid;
         features: Features.CommmonFeatures;
         gridEvents: ExternalEvents.GridEventsManager;
@@ -42,9 +41,22 @@ namespace Grid {
         changeProperty(propertyName: string, propertyValue: any): void;
         clearAllChanges(): void;
         getChangesMade(): changesDone;
-        /** Get the column on the grid by giving a columnID or a binding. */
+        /**
+         * Get the column on the grid by giving a columnID or a binding.
+         * @param key key can be the uniqueId or a binding of a column
+         * @returns Column with the same columnID or binding.
+         */
         getColumn(key: string): Column.IColumn;
+        /** Return an array containing all grid's column
+         * @returns Array of grid's columns
+         */
+        getColumns(): Column.IColumn[];
         getData(): JSON[];
+        /**
+         * Verifies grid has the given Column
+         * @param key key can be the uniqueId or a binding of a column
+         */
+        hasColumn(key: string): boolean;
         /**
          * Look to DOM trying to find if some column was defined for this Grid
          */
@@ -64,6 +76,7 @@ namespace Grid {
         implements IGridGeneric<W> {
         private _addedRows: InternalEvents.AddNewRowEvent;
         private _columns: Map<string, Column.IColumn>;
+        private _columnsSet: Set<Column.IColumn>;
         private _configs: Z;
         private _gridEvents: ExternalEvents.GridEventsManager;
         private _isReady: boolean;
@@ -102,10 +115,6 @@ namespace Grid {
             return this._widgetId;
         }
 
-        public get columns(): Map<string, Column.IColumn> {
-            return this._columns;
-        }
-
         public get isReady(): boolean {
             return this._isReady;
         }
@@ -137,7 +146,9 @@ namespace Grid {
 
         public addColumn(col: Column.IColumn): void {
             console.log(`Add column '${col.uniqueId}': '${col.config.header}'`);
+            this._columns.set(col.config.binding, col);
             this._columns.set(col.uniqueId, col);
+            this._columnsSet.add(col);
         }
 
         public build(): void {
@@ -158,19 +169,20 @@ namespace Grid {
             return gridID === this._uniqueId || gridID === this._widgetId;
         }
 
-        /**
-         * Get the column on the grid by giving a columnID or a binding.
-         * @param key key can be a columnID or a binding of a column
-         * @returns Column with the same columnID or binding.
-         */
         public getColumn(key: string): Column.IColumn {
             if (this._columns.has(key)) {
                 return this._columns.get(key);
             } else {
-                return _.toArray(this.columns)
-                    .map((p) => p[1])
-                    .find((p) => p && p.equalsToID(key));
+                return this.getColumns().find((p) => p && p.equalsToID(key));
             }
+        }
+
+        public getColumns(): Column.IColumn[] {
+            return Array.from(this._columnsSet);
+        }
+
+        public hasColumn(key: string): boolean {
+            return this._columns.has(key);
         }
 
         public hasColumnsDefined(): boolean {
@@ -190,6 +202,7 @@ namespace Grid {
                 col.dispose();
                 this._columns.delete(columnID);
                 this._columns.delete(col.config.binding);
+                this._columnsSet.delete(col);
 
                 console.log(
                     `Remove column '${columnID}': '${col.config.header}'`

--- a/code/src/Grid/AbstractGrid.ts
+++ b/code/src/Grid/AbstractGrid.ts
@@ -90,6 +90,7 @@ namespace Grid {
         constructor(uniqueId: string, configs: Z) {
             this._uniqueId = uniqueId;
             this._columns = new Map<string, Column.IColumn>();
+            this._columnsSet = new Set<Column.IColumn>();
             this._configs = configs;
             this._addedRows = new InternalEvents.AddNewRowEvent();
             this._gridEvents = new ExternalEvents.GridEventsManager(this);

--- a/code/src/Grid/FlexGrid.ts
+++ b/code/src/Grid/FlexGrid.ts
@@ -16,7 +16,7 @@ namespace Grid {
 
         private _addColumns(cols: Column.IColumn[]): void {
             cols.forEach((col) => {
-                this.columns.set(col.config.binding, col);
+                super.addColumn(col);
             });
 
             this._buildColumns();
@@ -24,7 +24,7 @@ namespace Grid {
 
         // eslint-disable-next-line @typescript-eslint/member-ordering
         private _buildColumns(): void {
-            this.columns.forEach((col) => col.build());
+            this.getColumns().forEach((col) => col.build());
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -300,7 +300,7 @@ namespace Grid {
                             this._parseNewItem(infojson.metadata)
                         );
                         // Check if the binding from the custom columns exist on the metadata from the original data source.
-                        this.columns.forEach((column) => {
+                        this.getColumns().forEach((column) => {
                             if (column.config.validateBinding === false) return;
                             // Split the binding of the column by every dot. (e.g Sample_product.Name -> ['Sample_Product', 'Name'])
                             const bindingMatches = column.config.binding.split(

--- a/code/src/Helpers/JSONParser.ts
+++ b/code/src/Helpers/JSONParser.ts
@@ -77,8 +77,8 @@ namespace Helper {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): void {
         //TODO: [RGRIDT-638] Regression 2021-02-12: Is this method the best solution
-        const columns = _.toArray(grid.columns)
-            .map((pair) => pair[1] as Column.IColumn)
+        const columns = grid
+            .getColumns()
             .filter((p) => p.columnType === Column.ColumnType.Date);
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### What was happening
* Load view isn't working on production

### What was done
* The column.binding is back to the columns Map
* Created new methods _getColumns(): []_, _hasColumn(key: string)_
* To avoid the usage of grid.columns as an array, the getter was removed, and the methods _hasColumn_, _getColumn_ and _getColumns_ should be used on its place

### Test Steps
1. Test the Validations
2. Test the Save/Load View

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

