### PR TITLE
Hotfix for width and visibility during Save/Load View

### DIFF
--- a/code/src/Columns/Configuration.ts
+++ b/code/src/Columns/Configuration.ts
@@ -59,7 +59,7 @@ namespace Column {
                 multiLine: this.multiLine,
                 dataType: this.dataType,
                 editor: this.editor,
-                width: this.width > 0 ? this.width : undefined // when the column's width is not set, the default value should be managed by wijmo
+                width: this.width > 0 ? this.width : null // when the column's width is not set, the default value should be managed by wijmo
             };
 
             //Cleanning undefined properties

--- a/code/src/Features/View.ts
+++ b/code/src/Features/View.ts
@@ -11,6 +11,24 @@ namespace Features {
         }
 
         /**
+         * Returns the column layout
+         */
+        private _getColumnLayout(): string {
+            //Today we save only visible and width
+            //Properties that the user can manipulate on his side, everything else should come from the OS
+            //The column position consider its position inside the array
+            return JSON.stringify(
+                this._grid.provider.columns.map((p) => {
+                    return {
+                        binding: p.binding,
+                        visible: p.visible === undefined ? true : p.visible,
+                        width: p.width
+                    };
+                })
+            );
+        }
+
+        /**
          * Internal method used to apply configurations to columns
          * @param state The provider config received used to load view
          */
@@ -19,7 +37,7 @@ namespace Features {
             const config = JSON.parse(state.columns);
             let i = 0; //Used to control the appearance of saved columns
 
-            config.columns.forEach((providerConfing) => {
+            config.forEach((providerConfing) => {
                 // * We build the columns based on OS configuration, than we load the configurations for the available columns
                 //   This should avoid errors like, a binding isn't present on the grid, or the developer have to remove some column (for securety maybe)
                 // * Different from the web version, new columns (inserted by the developer after the user "SaveConfig") will now appear on the grid, as rightmost columns
@@ -45,7 +63,7 @@ namespace Features {
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         public getViewLayout(): any {
             const state = {
-                columns: this._grid.provider.columnLayout,
+                columns: this._getColumnLayout(),
                 filterDefinition: this._grid.features.filter.getViewLayout(),
                 groupDescriptions: this._grid.features.groupPanel.getViewLayout(),
                 sortDescriptions: this._grid.features.sort.getViewLayout()


### PR DESCRIPTION
### What was happening
* Width wasn't being reseted when width = undefined
* Visible wasn't being reseted when visible = undefined

### What was done
* Placing defaults for width and visible, null and true respectively

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

