### PR TITLE
Corrections to the PR

### DIFF
--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -102,6 +102,7 @@ namespace OSFramework.Grid {
     }
 
     export abstract class AbstractDataSource implements IDataSource {
+        private _isSingleEntity: boolean;
         protected _convertions: Map<string, Set<string>>;
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         protected _ds: Array<any>;
@@ -111,6 +112,7 @@ namespace OSFramework.Grid {
             // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
             this._ds = new Array<any>();
             this._convertions = new Map<string, Set<string>>();
+            this._isSingleEntity = false;
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -153,10 +155,15 @@ namespace OSFramework.Grid {
         }
 
         public get isSingleEntity(): boolean {
-            return Object.keys(this._ds[0] || {}).length <= 1;
+            return this._isSingleEntity;
         }
 
-        public addRow(position?: number, data?: JSON[]) {
+        public addRow(position?: number, data?: JSON[]): void {
+            if (this.isSingleEntity) {
+                for (let i = 0; i < data.length; i++) {
+                    data[i] = this._parseNewItem();
+                }
+            }
             this._ds.splice(position, 0, ...data);
         }
 
@@ -191,6 +198,8 @@ namespace OSFramework.Grid {
             const dataJson = ToJSONFormat(data, this._convertions);
 
             this._metadata = dataJson.metadata;
+
+            this._isSingleEntity = Object.keys(dataJson.data[0] || {}).length <= 1;
 
             if (this.hasMetadata) {
                 this._ds.push(...dataJson.data);

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -79,7 +79,7 @@ namespace OSFramework.Grid {
         data: Array<any>
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): void {
-        const columns = convertions.get('date');
+        const columns = convertions.get('date') || [];
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const setDeepDate = (binding: string, object: any) => {
@@ -199,17 +199,18 @@ namespace OSFramework.Grid {
 
             this._metadata = dataJson.metadata;
 
-            this._isSingleEntity = Object.keys(dataJson.data[0] || {}).length <= 1;
+            this._isSingleEntity =
+                Object.keys(dataJson.data[0] || {}).length <= 1;
 
             if (this.hasMetadata) {
-                this._ds.push(...dataJson.data);
+                this._ds = [...dataJson.data];
             } else {
-                this._ds.push(...dataJson);
+                this._ds = [...dataJson];
             }
         }
 
         public toOSFormat(dataItem: any): any {
-            return this._getChangesString(dataItem);
+            return this._getChangesString([dataItem]);
         }
 
         public abstract build(): void;

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -200,7 +200,7 @@ namespace OSFramework.Grid {
             this._metadata = dataJson.metadata;
 
             this._isSingleEntity =
-                Object.keys(dataJson.data[0] || {}).length <= 1;
+                Object.keys(dataJson[0] || dataJson.data[0] || {}).length <= 1;
 
             if (this.hasMetadata) {
                 this._ds = [...dataJson.data];

--- a/code/src/OSFramework/OSStructure/RowData.ts
+++ b/code/src/OSFramework/OSStructure/RowData.ts
@@ -24,13 +24,15 @@ namespace OSFramework.OSStructure {
         ) {
             this._grid = grid;
             this.rowIndex = rowIndex;
+            this.dataItem = dataItem;
             this.selected = selected || new Array<BindingValue>();
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public serialize(): any {
             return {
-                ...this,
+                rowIndex: this.rowIndex,
+                selected: this.selected,
                 dataItem: this._grid.dataSource.toOSFormat(this.dataItem)
             };
         }

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -195,6 +195,11 @@ namespace WijmoProvider.Feature {
 
             this._grid.dataSource.addRow(topRowIndex, items);
 
+            // Trigger the event of adding the new row that will add the dirty mark to the added row
+            for (let index = 0; index < quantity; index++) {
+                this._grid.addedRows.trigger(topRowIndex + index);
+            }
+
             // Trigger the method responsible for setting the row as new in the metadata of the row
             this._grid.addedRows.trigger(topRowIndex);
 


### PR DESCRIPTION
This PR is based on [RGRIDT-748 - DataSource review](https://github.com/OutSystems/outsystems-datagrid-reactive/pull/74)

### What was happening
* The new item that was being added to the rows with the "Add New Row" action wasn't considering the dataItem column name keys. So, when the row was added, we were not able to edit the cells from the same rows.
* After adding new rows, only the first row had dirty marks.
* The search by server-side was "pushing" new rows to the grid instead of filtering the old ones.
* Get All Selections Data and Get Selected Rows Data from the API were adding the grid to the returning objects

### What was done
* Added parseNewItem to the addRow method
* Triggered the event of adding the new row to add the dirty marks to new rows
* Fixed the Search mechanism for a value with server side
* Fixed the GetAllSelectionsData and GetSelectedRowsData API methods

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

