### PR TITLE
RGRIDT-791: Removed the validation isSingleEntity from addRows

### DIFF
--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -8,7 +8,7 @@ namespace OSFramework.Grid {
     function FlattenArray(dataArray: JSON[]): JSON[] {
         const returnDataArray = [];
         dataArray.forEach((item) => {
-            returnDataArray.push(OSFramework.Helper.Flatten(item));
+            returnDataArray.push(Helper.Flatten(item));
         });
 
         return returnDataArray;
@@ -115,7 +115,7 @@ namespace OSFramework.Grid {
             this._isSingleEntity = false;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
         protected _getChangesString(itemsChanged: any): string {
             let tempArray = itemsChanged.map((p) => _.cloneDeep(p));
 
@@ -159,10 +159,8 @@ namespace OSFramework.Grid {
         }
 
         public addRow(position?: number, data?: JSON[]): void {
-            if (this.isSingleEntity) {
-                for (let i = 0; i < data.length; i++) {
-                    data[i] = this._parseNewItem();
-                }
+            for (let i = 0; i < data.length; i++) {
+                data[i] = this._parseNewItem();
             }
             this._ds.splice(position, 0, ...data);
         }
@@ -209,23 +207,19 @@ namespace OSFramework.Grid {
             }
         }
 
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         public toOSFormat(dataItem: any): any {
             return this._getChangesString([dataItem]);
         }
 
         public abstract build(): void;
-
         public abstract clear(): void;
-
-        public abstract search(info: string): void;
-
-        public abstract getChanges<
-            T extends OSFramework.OSStructure.ChangesDone
-        >(c: new () => T): T;
-
+        public abstract getChanges<T extends OSStructure.ChangesDone>(
+            c: new () => T
+        ): T;
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         public abstract getProviderDataSource(): any;
-
         public abstract hasResults(): boolean;
+        public abstract search(info: string): void;
     }
 }


### PR DESCRIPTION
This PR is for RGRIDT-791: Can't edit new added rows on grid with multiple entities.

### What was happening
* When the data from the Grid has additional attributes on the aggregate that later feeds the grid with data and you try to add rows to the grid using the API (GridAPI.AddRows), it's impossible to edit the values of those new cells.

### What was done
* There was an if statement inside the addRows method (from AbstractDataSource.ts) that was only considering the creation of new dataItems when the grid had a single entity. (e.g. json received -> {"Sample_Product": {Id: 1, Name: "NameValue", Description: "DescriptionValue",  … }). With this fix, that removed that if statement, we should be able to allow the creation of new dataItems for multiple entities (e.g. {"Entity1": {Id: 1, Type: 5}, "Sample_Product": {Id: 1, Name: "NameValue", Description: "DescriptionValue",  … }). We can go with the following structure as well: {Id: 1, Name: "NameValue", Description: "DescriptionValue",  … } 

### Checklist
* [x] tested locally
* [ ] documented the code - **NA**
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes) - **NA**
* [ ] requires new sample page in OutSystems (if so, provide a module with changes) - **NA**

