### PR TITLE
RGRIDT-792: Fix visiblity behavior after changing properties with columns inside group panel 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 
+code/*.bat

--- a/code/src/OSFramework/Feature/IGroupPanel.ts
+++ b/code/src/OSFramework/Feature/IGroupPanel.ts
@@ -1,7 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Feature {
     export interface IGroupPanel extends Interface.IValidation, IView {
+        /** Boolean that indicates whether the grid is grouped or not */
         isGridGrouped: boolean;
+        /**
+         * Check if the column is inside the Group Panel
+         * @param binding binding of the column
+         */
         columnInGroupPanel(binding: string): boolean;
     }
 }

--- a/code/src/OSFramework/Feature/IGroupPanel.ts
+++ b/code/src/OSFramework/Feature/IGroupPanel.ts
@@ -2,5 +2,6 @@
 namespace OSFramework.Feature {
     export interface IGroupPanel extends Interface.IValidation, IView {
         isGridGrouped: boolean;
+        columnInGroupPanel(binding: string): boolean;
     }
 }

--- a/code/src/WijmoProvider/Columns/AbstractProviderColumn.ts
+++ b/code/src/WijmoProvider/Columns/AbstractProviderColumn.ts
@@ -26,27 +26,38 @@ namespace WijmoProvider.Column {
             this._provider = provider;
         }
 
+        /**
+         * Checks if the visibility of the provider is True or False depending on the provider configs,
+         * wijmo's column and if the column is in the group panel or unchecked in the column picker
+         */
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+        protected _getVisibility(): boolean {
+            const providerConfig = this.getProviderConfig();
+            const inGroupPanel = this.grid.features.groupPanel.columnInGroupPanel(
+                this.config.binding
+            );
+            const inColumnPicker = !this.provider.isVisible && !inGroupPanel;
+
+            // We need to make sure the columns is visible only if the provider and our providerConfig
+            // share the same value of visibility for the column AND the column is not on the group panel,
+            // also considering if it is hidden or not on the column picker.
+            return (
+                (providerConfig.visible &&
+                    this.provider.isVisible &&
+                    !inGroupPanel &&
+                    !inColumnPicker) ||
+                (providerConfig.visible &&
+                    !this.provider.isVisible &&
+                    !inGroupPanel &&
+                    inColumnPicker)
+            );
+        }
+
         public applyConfigs(): void {
             if (this.isReady) {
                 const providerConfig = this.getProviderConfig();
 
-                const inGroupPanel = this.grid.features.groupPanel.columnInGroupPanel(
-                    this.config.binding
-                );
-                const inColumnPicker =
-                    !this.provider.isVisible && !inGroupPanel;
-
-                // We need to make sure the columns is visible only if the provider and our providerConfig
-                // share the same value of visibility for the column
-                providerConfig.visible =
-                    (providerConfig.visible &&
-                        this.provider.isVisible &&
-                        !inGroupPanel &&
-                        !inColumnPicker) ||
-                    (providerConfig.visible &&
-                        !this.provider.isVisible &&
-                        !inGroupPanel &&
-                        inColumnPicker);
+                providerConfig.visible = this._getVisibility();
 
                 wijmo.copy(this.provider, providerConfig);
             } else {

--- a/code/src/WijmoProvider/Columns/AbstractProviderColumn.ts
+++ b/code/src/WijmoProvider/Columns/AbstractProviderColumn.ts
@@ -30,10 +30,23 @@ namespace WijmoProvider.Column {
             if (this.isReady) {
                 const providerConfig = this.getProviderConfig();
 
+                const inGroupPanel = this.grid.features.groupPanel.columnInGroupPanel(
+                    this.config.binding
+                );
+                const inColumnPicker =
+                    !this.provider.isVisible && !inGroupPanel;
+
                 // We need to make sure the columns is visible only if the provider and our providerConfig
-                // share the same value for visibility of the column
+                // share the same value of visibility for the column
                 providerConfig.visible =
-                    providerConfig.visible && this.provider.isVisible;
+                    (providerConfig.visible &&
+                        this.provider.isVisible &&
+                        !inGroupPanel &&
+                        !inColumnPicker) ||
+                    (providerConfig.visible &&
+                        !this.provider.isVisible &&
+                        !inGroupPanel &&
+                        inColumnPicker);
 
                 wijmo.copy(this.provider, providerConfig);
             } else {

--- a/code/src/WijmoProvider/Columns/AbstractProviderColumn.ts
+++ b/code/src/WijmoProvider/Columns/AbstractProviderColumn.ts
@@ -28,7 +28,14 @@ namespace WijmoProvider.Column {
 
         public applyConfigs(): void {
             if (this.isReady) {
-                wijmo.copy(this.provider, this.getProviderConfig());
+                const providerConfig = this.getProviderConfig();
+
+                // We need to make sure the columns is visible only if the provider and our providerConfig
+                // share the same value for visibility of the column
+                providerConfig.visible =
+                    providerConfig.visible && this.provider.isVisible;
+
+                wijmo.copy(this.provider, providerConfig);
             } else {
                 console.log('applyConfigs - Column needs to be build');
             }

--- a/code/src/WijmoProvider/Columns/AbstractProviderColumnEditor.ts
+++ b/code/src/WijmoProvider/Columns/AbstractProviderColumnEditor.ts
@@ -38,10 +38,23 @@ namespace WijmoProvider.Column {
                 const providerConfig = this.getProviderConfig();
                 delete providerConfig.editor;
 
+                const inGroupPanel = this.grid.features.groupPanel.columnInGroupPanel(
+                    this.config.binding
+                );
+                const inColumnPicker =
+                    !this.provider.isVisible && !inGroupPanel;
+
                 // We need to make sure the columns is visible only if the provider and our providerConfig
                 // share the same value for visibility of the column
                 providerConfig.visible =
-                    this.provider.isVisible && providerConfig.visible;
+                    (providerConfig.visible &&
+                        this.provider.isVisible &&
+                        !inGroupPanel &&
+                        !inColumnPicker) ||
+                    (providerConfig.visible &&
+                        !this.provider.isVisible &&
+                        !inGroupPanel &&
+                        inColumnPicker);
 
                 wijmo.copy(this.provider, providerConfig);
                 wijmo.copy(

--- a/code/src/WijmoProvider/Columns/AbstractProviderColumnEditor.ts
+++ b/code/src/WijmoProvider/Columns/AbstractProviderColumnEditor.ts
@@ -38,6 +38,11 @@ namespace WijmoProvider.Column {
                 const providerConfig = this.getProviderConfig();
                 delete providerConfig.editor;
 
+                // We need to make sure the columns is visible only if the provider and our providerConfig
+                // share the same value for visibility of the column
+                providerConfig.visible =
+                    this.provider.isVisible && providerConfig.visible;
+
                 wijmo.copy(this.provider, providerConfig);
                 wijmo.copy(
                     this._editor,

--- a/code/src/WijmoProvider/Columns/AbstractProviderColumnEditor.ts
+++ b/code/src/WijmoProvider/Columns/AbstractProviderColumnEditor.ts
@@ -38,23 +38,7 @@ namespace WijmoProvider.Column {
                 const providerConfig = this.getProviderConfig();
                 delete providerConfig.editor;
 
-                const inGroupPanel = this.grid.features.groupPanel.columnInGroupPanel(
-                    this.config.binding
-                );
-                const inColumnPicker =
-                    !this.provider.isVisible && !inGroupPanel;
-
-                // We need to make sure the columns is visible only if the provider and our providerConfig
-                // share the same value for visibility of the column
-                providerConfig.visible =
-                    (providerConfig.visible &&
-                        this.provider.isVisible &&
-                        !inGroupPanel &&
-                        !inColumnPicker) ||
-                    (providerConfig.visible &&
-                        !this.provider.isVisible &&
-                        !inGroupPanel &&
-                        inColumnPicker);
+                providerConfig.visible = this._getVisibility();
 
                 wijmo.copy(this.provider, providerConfig);
                 wijmo.copy(

--- a/code/src/WijmoProvider/Features/GroupPanel.ts
+++ b/code/src/WijmoProvider/Features/GroupPanel.ts
@@ -45,11 +45,11 @@ namespace WijmoProvider.Feature {
             OSFramework.Interface.IBuilder,
             OSFramework.Interface.IDisposable {
         private _currGroupDescription: Array<wijmo.collections.PropertyGroupDescription>;
-        private _grid: WijmoProvider.Grid.IGridWijmo;
+        private _grid: Grid.IGridWijmo;
         private _groupPanel: wijmo.grid.grouppanel.GroupPanel;
         private _panelId: string;
 
-        constructor(grid: WijmoProvider.Grid.IGridWijmo, panelId: string) {
+        constructor(grid: Grid.IGridWijmo, panelId: string) {
             this._grid = grid;
             this._panelId = panelId;
         }
@@ -83,6 +83,12 @@ namespace WijmoProvider.Feature {
                     //Updates the global variable wih the current config
                     this._currGroupDescription = o.slice();
                 }
+            );
+        }
+
+        public columnInGroupPanel(binding: string): boolean {
+            return this._groupPanel._hiddenCols.some(
+                (col) => col.binding === binding
             );
         }
 


### PR DESCRIPTION
This PR is for RGRIDT-792: Fix visiblity behavior after changing properties with columns inside group panel 

### What was happening
* If you move a column to the group panel and then select the same column (on the sample) to change any parameter from optional configs you can see that the same column is appearing on the grid (again) even though it is also being shown in the group panel. The problem seems to come from the method applyConfigs and the isVisible parameter from columns.

### What was done
* Added more code to make sure the visibility is right when passed into the providerConfigs which are going to get copied into the provider (Wijmo's columns)

### Screenshots
BUG:
![Bug](https://user-images.githubusercontent.com/6432232/118142468-51c91900-b402-11eb-9027-bf549e0dcb6b.gif)


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes) -**NA**
* [ ] requires new sample page in OutSystems (if so, provide a module with changes) - **NA**

