### PR TITLE
Fix Dropdown Columns visibility

### DIFF
--- a/code/src/WijmoProvider/Columns/DropdownColumn.ts
+++ b/code/src/WijmoProvider/Columns/DropdownColumn.ts
@@ -39,6 +39,8 @@ namespace WijmoProvider.Column {
                 const providerConfig = this.getProviderConfig();
                 delete providerConfig.dataMap;
 
+                providerConfig.visible = this._getVisibility();
+
                 wijmo.copy(this.provider, providerConfig);
             } else {
                 console.log('applyConfigs - Column needs to be build');


### PR DESCRIPTION
This PR is for RGRIDT-792: Fix visiblity behavior after changing properties with columns inside group panel 

### What was happening
* If you move a column to the group panel and then select the same column (on the sample) to change any parameter from optional configs you can see that the same column is appearing on the grid (again) even though it is also being shown in the group panel. The problem seems to come from the method applyConfigs and the isVisible parameter from columns.

### What was done
* Added more code to make sure the visibility is right when passed into the providerConfigs which are going to get copied into the provider (Wijmo's columns)

### Screenshots
BUG:
![Bug](https://user-images.githubusercontent.com/6432232/118142468-51c91900-b402-11eb-9027-bf549e0dcb6b.gif)


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes) -**NA**
* [ ] requires new sample page in OutSystems (if so, provide a module with changes) - **NA**

