### PR TITLE
Added logic to disable mandatory column's checkboxes

### DIFF
--- a/code/src/WijmoProvider/Features/ColumnPicker.ts
+++ b/code/src/WijmoProvider/Features/ColumnPicker.ts
@@ -149,6 +149,16 @@ namespace WijmoProvider.Feature {
             this._theColumnPicker = new wijmo.input.ListBox(picker, {
                 checkedMemberPath: 'visible',
                 displayMemberPath: 'header',
+                formatItem: (sender, e) => {
+                    e.item.innerHTML =  `<div class="wj-listbox-item__inner">`+
+                                        `<input class="wj-listbox-item__input" type="checkbox" ${e.data.isRequired ? 'disabled' : '' }>` +
+                                        `<span class="wj-listbox-item__label">${e.data.header}</span>`+
+                                        `</div>`;
+                    if(e.data.visible) {
+                        e.item.querySelector('input').checked = true;
+                        e.item.querySelector('input').setAttribute("checked", "true");
+                    }
+                },
                 //Undo Stack Enable
                 itemChecked: (s: wijmo.input.ListBox) => {
                     const _item = s.selectedItem;


### PR DESCRIPTION
In the continuation of the discussion started in the [components forge page](https://www.outsystems.com/forums/discussion/70842/option-mandatoryongrid/), please find below the required code for this functionality.

### What was happening
* The Data Grid is missing the ability to avoid the end-user from hiding a specific column, by making the check box of the respective column disabled, as the image below shows:
![image](https://user-images.githubusercontent.com/10534623/121023626-212f9180-c7ac-11eb-813a-1f91eda2d2ac.png)

### What was done
* A new boolean field was added to the optional configs structure
* This new boolean will then set the check box of that column as disabled throught the 'formatItem' callback.
* That will add disabled attribute to the checkboxes of the items that are being passed with the property 'isRequired' as true

### Test Steps
1. after update outsystems module, pass a column with the parameter 'isRequired' as 'true' and other(s) as 'false'
2. use the column picker and note that the columns that were passed with 'isRequired' property as true have the checkboxes disabled, so the column cannot be hidden from the grid.



### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes) => just pass a new input for columns 'isRequired' and and it to the column options so it can be checked in JS ListBox class as column.isRequired
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

