### PR TITLE
RGRIDT-843: Fixing add rows when changing pages

### DIFF
--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -199,7 +199,7 @@ namespace WijmoProvider.Feature {
 
             providerGrid.focus(); // In case of Undo action, the user will not need to click on the grid to undo.
 
-            this._grid.dataSource.addRow(topRowIndex, items);
+            this._grid.dataSource.addRow(dsTopRowIndex, items);
 
             // Trigger the event of adding the new row that will add the dirty mark to the added row
             for (let index = 0; index < quantity; index++) {


### PR DESCRIPTION
This PR is for Fixing add rows when changing pages

### What was happening
* There was a bug when you added rows when changing pages

### What was done
* Adjusted the row index to respect page index as well.

### Test Steps
1. Change pages
2. Add rows
3. A new and empty row should be added to the selected position and the first cell from the same row should get focused.


### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

