### PR TITLE
RGRID-735: Review getSelectedRows function to only return unique identifiers.

### DIFF
--- a/code/src/GridAPI/ContextMenu.ts
+++ b/code/src/GridAPI/ContextMenu.ts
@@ -17,9 +17,8 @@ namespace GridAPI.ContextMenu {
     ): string {
         //Try to find in DOM only if not present on Map
         if (lookUpDOM && !_menuItemsToGridId.has(menuItemId)) {
-            const menuOptionElement = OSFramework.Helper.GetElementByUniqueId(
-                menuItemId
-            );
+            const menuOptionElement =
+                OSFramework.Helper.GetElementByUniqueId(menuItemId);
             const grid = OSFramework.Helper.GetClosestGrid(menuOptionElement);
 
             if (grid) {

--- a/code/src/WijmoProvider/Features/Selection.ts
+++ b/code/src/WijmoProvider/Features/Selection.ts
@@ -309,7 +309,9 @@ namespace WijmoProvider.Feature {
                     );
                 });
 
-            return rows;
+            // Return only unique indexes (check if there are duplicated indexes)
+            // Duplicate indexes could be retuned when the mouse and ctrl was used for selection
+            return rows.filter((item, index) => rows.indexOf(item) === index);
         }
 
         public getSelectedRowsCount(): number {


### PR DESCRIPTION
This PR is for RGRID-735: GridAPI.Selection doesn't return the correct values

### What was happening
* When playing with the grid, sometimes the API return more selected rows count than expected.


### What was done
* Review the output for getSelectedRows() method in Selection.ts under WijmoProvider\Features 
* Return only unique indexes (check if there are duplicated indexes)
*  Duplicate indexes could be returned when the mouse and ctrl was used for selection

### Test Steps
1. Load the page
2. Hold Ctrl pressed
3. Click and row2 and drag it to row3
4. Click on "Get selected rows count"
5. The API returns 4 instead of 2.


### Screenshots
- Issue https://www.screencast.com/t/5u6EdVft
- With the change: https://www.screencast.com/t/862Gn4ad7p


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [x] requires new sample page in OutSystems (if so, provide a module with changes)

