### PR TITLE
RGRIDT-780: Dropdown dependency columns

### DIFF
--- a/code/src/GridAPI/ContextMenu.ts
+++ b/code/src/GridAPI/ContextMenu.ts
@@ -17,9 +17,8 @@ namespace GridAPI.ContextMenu {
     ): string {
         //Try to find in DOM only if not present on Map
         if (lookUpDOM && !_menuItemsToGridId.has(menuItemId)) {
-            const menuOptionElement = OSFramework.Helper.GetElementByUniqueId(
-                menuItemId
-            );
+            const menuOptionElement =
+                OSFramework.Helper.GetElementByUniqueId(menuItemId);
             const grid = OSFramework.Helper.GetClosestGrid(menuOptionElement);
 
             if (grid) {

--- a/code/src/OSFramework/Configuration/Column/ColumnConfigDropdown.ts
+++ b/code/src/OSFramework/Configuration/Column/ColumnConfigDropdown.ts
@@ -9,12 +9,14 @@ namespace OSFramework.Configuration.Column {
         public dataMapEditor: any;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public dropdownOptions: any;
+        public filterBinding: string;
 
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         constructor(config: any, extra: any) {
             super(config);
             this.dataMap = undefined;
             this.dropdownOptions = extra.datamap;
+            this.filterBinding = extra.filterBinding;
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/code/src/OSFramework/Configuration/Column/ColumnConfigDropdown.ts
+++ b/code/src/OSFramework/Configuration/Column/ColumnConfigDropdown.ts
@@ -9,14 +9,14 @@ namespace OSFramework.Configuration.Column {
         public dataMapEditor: any;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public dropdownOptions: any;
-        public filterBinding: string;
+        public parentBinding: string;
 
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         constructor(config: any, extra: any) {
             super(config);
             this.dataMap = undefined;
             this.dropdownOptions = extra.datamap;
-            this.filterBinding = extra.filterBinding;
+            this.parentBinding = extra.parentBinding;
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/code/src/OSFramework/Feature/IDirtyMark.ts
+++ b/code/src/OSFramework/Feature/IDirtyMark.ts
@@ -5,5 +5,6 @@ namespace OSFramework.Feature {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         getOldValue(rowNumber: number, binding: string): any;
         // clearByRow(row: number): void;
+        saveOriginalValue(rowNumber: number, columnNumber: number): void;
     }
 }

--- a/code/src/OSFramework/Feature/IDirtyMark.ts
+++ b/code/src/OSFramework/Feature/IDirtyMark.ts
@@ -5,6 +5,12 @@ namespace OSFramework.Feature {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         getOldValue(rowNumber: number, binding: string): any;
         // clearByRow(row: number): void;
+
+        /**
+         * Saves cell original value
+         * @param rowNumber Cell's row number
+         * @param columnNumber Cell's column number
+         */
         saveOriginalValue(rowNumber: number, columnNumber: number): void;
     }
 }

--- a/code/src/OSFramework/Grid/AbstractGrid.ts
+++ b/code/src/OSFramework/Grid/AbstractGrid.ts
@@ -154,10 +154,8 @@ namespace OSFramework.Grid {
                         validate(binding, column.config.binding)
                     );
                     // validate dropdown dependency columns
-                    // @ts-ignore
-                    if (column.config.parentBinding) {
-                        // @ts-ignore
-                        const parentBinding = column.config.parentBinding;
+                    if (column.config.hasOwnProperty('parentBinding')) {
+                        const parentBinding = column.config['parentBinding'];
                         const parentBindingMatches = parentBinding.split('.');
                         
                         // reset metadata

--- a/code/src/OSFramework/Grid/AbstractGrid.ts
+++ b/code/src/OSFramework/Grid/AbstractGrid.ts
@@ -3,7 +3,8 @@ namespace OSFramework.Grid {
     export abstract class AbstractGrid<
         W,
         Z extends Configuration.IConfigurationGrid
-    > implements IGridGeneric<W> {
+    > implements IGridGeneric<W>
+    {
         private _addedRows: Event.Grid.AddNewRowEvent;
         private _columns: Map<string, Column.IColumn>;
         private _columnsGenerator: Column.IColumnGenerator;
@@ -139,16 +140,30 @@ namespace OSFramework.Grid {
                     // Split the binding of the column by every dot. (e.g Sample_product.Name -> ['Sample_Product', 'Name'])
                     const bindingMatches = column.config.binding.split('.');
                     let metadata = this.dataSource.getMetadata();
-                    bindingMatches.forEach((keyword) => {
+
+                    const validate = (keyword, binding) => {
                         // Check if the matching keyword is a property from metadata
                         if (metadata && !metadata.hasOwnProperty(keyword)) {
-                            throw `The binding "${
-                                column.config.binding
-                            }" doesn't match any valid column from the data you specified. ${'\n'} Expected format: "EntityName.FieldName". ${'\n'} For example: "Product_Sample.Name"`;
+                            throw `The binding "${binding}" doesn't match any valid column from the data you specified. ${'\n'} Expected format: "EntityName.FieldName". ${'\n'} For example: "Product_Sample.Name"`;
                         }
                         // If keyword is a property from metadata then use metadata[keyword] as the new metadata and iterate to the next keyword.
                         metadata = metadata[keyword];
-                    });
+                    };
+
+                    bindingMatches.forEach((binding) =>
+                        validate(binding, column.config.binding)
+                    );
+                    // validate dropdown dependency columns
+                    // @ts-ignore
+                    if (column.config.filterBinding) {
+                        // @ts-ignore
+                        const parentBinding = column.config.filterBinding;
+                        const parentBindingMatches = parentBinding.split('.');
+                        
+                        parentBindingMatches.forEach((binding) =>
+                            validate(binding, parentBinding)
+                        );
+                    }
                 });
             }
         }

--- a/code/src/OSFramework/Grid/AbstractGrid.ts
+++ b/code/src/OSFramework/Grid/AbstractGrid.ts
@@ -154,10 +154,13 @@ namespace OSFramework.Grid {
                         validate(binding, column.config.binding)
                     );
                     // validate dropdown dependency columns
-                    if (column.config.hasOwnProperty('parentBinding')) {
+                    if (
+                        column.config.hasOwnProperty('parentBinding') &&
+                        column.config['parentBinding'] !== ''
+                    ) {
                         const parentBinding = column.config['parentBinding'];
                         const parentBindingMatches = parentBinding.split('.');
-                        
+
                         // reset metadata
                         metadata = this.dataSource.getMetadata();
                         parentBindingMatches.forEach((binding) =>

--- a/code/src/OSFramework/Grid/AbstractGrid.ts
+++ b/code/src/OSFramework/Grid/AbstractGrid.ts
@@ -155,11 +155,13 @@ namespace OSFramework.Grid {
                     );
                     // validate dropdown dependency columns
                     // @ts-ignore
-                    if (column.config.filterBinding) {
+                    if (column.config.parentBinding) {
                         // @ts-ignore
-                        const parentBinding = column.config.filterBinding;
+                        const parentBinding = column.config.parentBinding;
                         const parentBindingMatches = parentBinding.split('.');
                         
+                        // reset metadata
+                        metadata = this.dataSource.getMetadata();
                         parentBindingMatches.forEach((binding) =>
                             validate(binding, parentBinding)
                         );

--- a/code/src/WijmoProvider/Columns/DropdownColumn.ts
+++ b/code/src/WijmoProvider/Columns/DropdownColumn.ts
@@ -80,11 +80,11 @@ namespace WijmoProvider.Column {
             super.build();
         }
         public changeDisplayValues(): void {
-            if (this.config.filterBinding) {
+            if (this.config.parentBinding) {
                 const dataMap = this.config.dataMap;
                 const values = dataMap.collectionView.items;
 
-                const column = this.grid.getColumn(this.config.filterBinding);
+                const column = this.grid.getColumn(this.config.parentBinding);
 
                 if (column) {
                     // set child column to non mandatory, so we can set it to blank when parent changes value
@@ -100,7 +100,7 @@ namespace WijmoProvider.Column {
                     // override getDisplayValues method to get values that
                     // correspond to the parent
                     dataMap.getDisplayValues = (dataItem) => {
-                        const colBinding = this.config.filterBinding.split('.');
+                        const colBinding = this.config.parentBinding.split('.');
                         let value = dataItem;
                         for (let i = 0; i < colBinding.length; i++) {
                             // in case we get undefined we want to break

--- a/code/src/WijmoProvider/Columns/DropdownColumn.ts
+++ b/code/src/WijmoProvider/Columns/DropdownColumn.ts
@@ -16,9 +16,32 @@ namespace WijmoProvider.Column {
                 )
             );
             this.config.dataMap = new wijmo.grid.DataMap([], 'key', 'text');
-            this._columnEvents = new OSFramework.Event.Column.ColumnEventsManager(
-                this
-            );
+            this._columnEvents =
+                new OSFramework.Event.Column.ColumnEventsManager(this);
+        }
+
+        private _parentCellValueChangeHandler(
+            gridID: string,
+            rowNumber: number,
+            columnID: string,
+            oldValue: any,
+            newValue: any
+        ): void {
+            // only set to blank if there is a different value
+            if (oldValue !== newValue) {
+                // trigger dirty mark
+                this.grid.features.dirtyMark.saveOriginalValue(
+                    rowNumber,
+                    this.provider.index
+                );
+                this.grid.provider.setCellData(
+                    rowNumber,
+                    this.provider.index,
+                    '',
+                    true
+                );
+                this.grid.features.validationMark.validateRow(rowNumber);
+            }
         }
 
         /** Returns all the events associated to the column */
@@ -42,17 +65,61 @@ namespace WijmoProvider.Column {
                 providerConfig.visible = this._getVisibility();
 
                 wijmo.copy(this.provider, providerConfig);
+                this.changeDisplayValues();
             } else {
                 console.log('applyConfigs - Column needs to be build');
             }
         }
 
         public build(): void {
-            (this.config
-                .dataMap as wijmo.grid.DataMap).collectionView.sourceCollection = this.config.dropdownOptions;
+            (
+                this.config.dataMap as wijmo.grid.DataMap
+            ).collectionView.sourceCollection = this.config.dropdownOptions;
             this.config.dataMapEditor = wijmo.grid.DataMapEditor.DropDownList;
 
             super.build();
+        }
+        public changeDisplayValues(): void {
+            if (this.config.filterBinding) {
+                const dataMap = this.config.dataMap;
+                const values = dataMap.collectionView.items;
+
+                const column = this.grid.getColumn(this.config.filterBinding);
+
+                // set child column to non mandatory, so we can set it to blank when parent changes value
+                this.provider.isRequired = false;
+
+                // on parent cell change subscription, to set child cell's to blank
+                column.columnEvents.addHandler(
+                    OSFramework.Event.Column.ColumnEventType.OnCellValueChange,
+                    this._parentCellValueChangeHandler.bind(this)
+                );
+
+                // override getDisplayValues method to get values that
+                // correspond to the parent
+                dataMap.getDisplayValues = (dataItem) => {
+                    const colBinding = this.config.filterBinding.split('.');
+                    let value = dataItem;
+                    for (let i = 0; i < colBinding.length; i++) {
+                        // in case we get undefined we want to break
+                        if (
+                            value === undefined &&
+                            i === colBinding.length - 1
+                        ) {
+                            break;
+                        }
+                        value = value[colBinding[i]];
+                    }
+
+                    // if there is no value, we don't return anything
+                    if (value) {
+                        const validValues = values.filter(
+                            (x) => x.parentKey === value.toString()
+                        );
+                        return validValues.map((value) => value.text);
+                    }
+                };
+            }
         }
 
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any

--- a/code/src/WijmoProvider/Columns/DropdownColumn.ts
+++ b/code/src/WijmoProvider/Columns/DropdownColumn.ts
@@ -29,7 +29,11 @@ namespace WijmoProvider.Column {
         ): void {
             // only set to blank if there is a different value
             if (oldValue !== newValue) {
-                // trigger dirty mark
+                const currentValue = this.grid.provider.getCellData(
+                    rowNumber,
+                    this.provider.index
+                );
+
                 this.grid.features.dirtyMark.saveOriginalValue(
                     rowNumber,
                     this.provider.index
@@ -41,6 +45,19 @@ namespace WijmoProvider.Column {
                     true
                 );
                 this.grid.features.validationMark.validateRow(rowNumber);
+
+                const column = this.grid.getColumn(columnID);
+
+                // trigger cell value change event
+                if (column) {
+                    this.columnEvents.trigger(
+                        OSFramework.Event.Column.ColumnEventType
+                            .OnCellValueChange,
+                        '',
+                        currentValue,
+                        rowNumber
+                    );
+                }
             }
         }
 

--- a/code/src/WijmoProvider/Columns/DropdownColumn.ts
+++ b/code/src/WijmoProvider/Columns/DropdownColumn.ts
@@ -86,39 +86,42 @@ namespace WijmoProvider.Column {
 
                 const column = this.grid.getColumn(this.config.filterBinding);
 
-                // set child column to non mandatory, so we can set it to blank when parent changes value
-                this.provider.isRequired = false;
+                if (column) {
+                    // set child column to non mandatory, so we can set it to blank when parent changes value
+                    this.provider.isRequired = false;
 
-                // on parent cell change subscription, to set child cell's to blank
-                column.columnEvents.addHandler(
-                    OSFramework.Event.Column.ColumnEventType.OnCellValueChange,
-                    this._parentCellValueChangeHandler.bind(this)
-                );
+                    // on parent cell change subscription, to set child cell's to blank
+                    column.columnEvents.addHandler(
+                        OSFramework.Event.Column.ColumnEventType
+                            .OnCellValueChange,
+                        this._parentCellValueChangeHandler.bind(this)
+                    );
 
-                // override getDisplayValues method to get values that
-                // correspond to the parent
-                dataMap.getDisplayValues = (dataItem) => {
-                    const colBinding = this.config.filterBinding.split('.');
-                    let value = dataItem;
-                    for (let i = 0; i < colBinding.length; i++) {
-                        // in case we get undefined we want to break
-                        if (
-                            value === undefined &&
-                            i === colBinding.length - 1
-                        ) {
-                            break;
+                    // override getDisplayValues method to get values that
+                    // correspond to the parent
+                    dataMap.getDisplayValues = (dataItem) => {
+                        const colBinding = this.config.filterBinding.split('.');
+                        let value = dataItem;
+                        for (let i = 0; i < colBinding.length; i++) {
+                            // in case we get undefined we want to break
+                            if (
+                                value === undefined &&
+                                i === colBinding.length - 1
+                            ) {
+                                break;
+                            }
+                            value = value[colBinding[i]];
                         }
-                        value = value[colBinding[i]];
-                    }
 
-                    // if there is no value, we don't return anything
-                    if (value) {
-                        const validValues = values.filter(
-                            (x) => x.parentKey === value.toString()
-                        );
-                        return validValues.map((value) => value.text);
-                    }
-                };
+                        // if there is no value, we don't return anything
+                        if (value) {
+                            const validValues = values.filter(
+                                (x) => x.parentKey === value.toString()
+                            );
+                            return validValues.map((value) => value.text);
+                        }
+                    };
+                }
             }
         }
 

--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -21,17 +21,7 @@ namespace WijmoProvider.Feature {
             grid: wijmo.grid.FlexGrid,
             e: wijmo.grid.CellRangeEventArgs
         ): void {
-            const binding = grid.getColumn(e.col).binding;
-
-            if (
-                !this._isNewRow(e.row) &&
-                !this._hasCellInitialValue(e.row, binding)
-            ) {
-                this.getMetadata(e.row).originalValues.set(
-                    binding,
-                    grid.getCellData(e.row, e.col, false)
-                );
-            }
+            this.saveOriginalValue(e.row, e.col);
         }
 
         private _formatItems(
@@ -204,6 +194,27 @@ namespace WijmoProvider.Feature {
 
         public hasMetadata(row: number): boolean {
             return this._metadata.hasOwnProperty(row, this._internalLabel);
+        }
+
+        public saveOriginalValue(
+            rowNumber: number,
+            columnNumber: number
+        ): void {
+            const binding = this._grid.provider.getColumn(columnNumber).binding;
+
+            if (
+                !this._isNewRow(rowNumber) &&
+                !this._hasCellInitialValue(rowNumber, binding)
+            ) {
+                this.getMetadata(rowNumber).originalValues.set(
+                    binding,
+                    this._grid.provider.getCellData(
+                        rowNumber,
+                        columnNumber,
+                        false
+                    )
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
This PR is for Dropdown dependency columns

### What was happening
* There was no way to add dependency between dropdown columns.

### What was done
* Created parentBinding attribute on dropdown config.
* Created datamap.getDisplayValues method to change values according to parent.
* Made some changes in DirtyMark feature in order to apply dirtyMark.
* Adjusted _validateBindings method, to validate parentBinding from dropdown columns as well.
* Fixed eslint on contextMenu api.


### Test Steps
Automated tests have been created and are waiting for approval.


### Screenshots
![dropdownDependency](https://user-images.githubusercontent.com/3113318/122429643-d6233480-cf8a-11eb-8ea5-6ec9edcf6fe4.gif)


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [x] requires new sample page in OutSystems (if so, provide a module with changes)

