### PR TITLE
RGRIDT-861: Adding the ability to export with a specific file name.

### DIFF
--- a/code/src/OSFramework/Feature/IExport.ts
+++ b/code/src/OSFramework/Feature/IExport.ts
@@ -2,7 +2,7 @@
 namespace OSFramework.Feature {
     export interface IExport {
         exportToClipboard(withHeaders: boolean): void;
-        exportToCsv(): void;
-        exportToExcel(withStyles: boolean): void;
+        exportToCsv(filename?: string): void;
+        exportToExcel(withStyles: boolean, filename?: string): void;
     }
 }

--- a/code/src/WijmoProvider/Features/Export.ts
+++ b/code/src/WijmoProvider/Features/Export.ts
@@ -1,7 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace WijmoProvider.Feature {
     export class Export
-        implements OSFramework.Feature.IExport, OSFramework.Interface.IBuilder {
+        implements OSFramework.Feature.IExport, OSFramework.Interface.IBuilder
+    {
         private _curPage: number;
         private _grid: WijmoProvider.Grid.IGridWijmo;
         private _pageSize: number;
@@ -66,10 +67,10 @@ namespace WijmoProvider.Feature {
             wijmo.Clipboard.copy(result);
         }
 
-        public exportToCsv(): void {
+        public exportToCsv(filename = 'DataGridReactive'): void {
             this._resetPagination();
 
-            const params = { fileName: 'DataGridReactive.csv' };
+            const params = { fileName: `${filename}.csv` };
             const result = this._grid.provider.getClipString(
                 this._getFullCellRange(),
                 true,
@@ -80,7 +81,10 @@ namespace WijmoProvider.Feature {
             wijmo.saveFile(result, params.fileName);
         }
 
-        public exportToExcel(withStyles: boolean): void {
+        public exportToExcel(
+            withStyles: boolean,
+            filename = 'DataGridReactive'
+        ): void {
             this._resetPagination();
             // include timeout in order to apply conditional format
             setTimeout(() => {
@@ -95,7 +99,7 @@ namespace WijmoProvider.Feature {
                     params
                 );
                 book.sheets[0].name = 'DataGrid Data';
-                book.save('DataGridReactive.xlsx');
+                book.save(`${filename}.xlsx`);
                 this._reApplyPagination();
             }, 10);
         }

--- a/code/src/WijmoProvider/Features/Export.ts
+++ b/code/src/WijmoProvider/Features/Export.ts
@@ -23,6 +23,14 @@ namespace WijmoProvider.Feature {
             );
         }
 
+        private _handleFilename(fileName: string, isCSV = false): string {
+            if (fileName === undefined || fileName === '') {
+                fileName = 'DataGridReactive';
+            }
+
+            return `${fileName}.${isCSV ? 'csv' : 'xlsx'}`;
+        }
+
         //Then re-apply the pagination
         private _reApplyPagination(): void {
             this._grid.features.pagination.changePageSize(this._pageSize);
@@ -67,10 +75,10 @@ namespace WijmoProvider.Feature {
             wijmo.Clipboard.copy(result);
         }
 
-        public exportToCsv(filename = 'DataGridReactive'): void {
+        public exportToCsv(filename?: string): void {
             this._resetPagination();
 
-            const params = { fileName: `${filename}.csv` };
+            const params = { fileName: this._handleFilename(filename, true) };
             const result = this._grid.provider.getClipString(
                 this._getFullCellRange(),
                 true,
@@ -81,10 +89,7 @@ namespace WijmoProvider.Feature {
             wijmo.saveFile(result, params.fileName);
         }
 
-        public exportToExcel(
-            withStyles: boolean,
-            filename = 'DataGridReactive'
-        ): void {
+        public exportToExcel(withStyles: boolean, filename: string): void {
             this._resetPagination();
             // include timeout in order to apply conditional format
             setTimeout(() => {
@@ -99,7 +104,7 @@ namespace WijmoProvider.Feature {
                     params
                 );
                 book.sheets[0].name = 'DataGrid Data';
-                book.save(`${filename}.xlsx`);
+                book.save(this._handleFilename(filename, false));
                 this._reApplyPagination();
             }, 10);
         }


### PR DESCRIPTION
This PR is for adding the ability for developers to provide the filename with which the excel/csv file will be exported with.

### What was happening
* The name of the excel/csv was hardcoded in the code

### What was done
* A new input parameter was added to the feature export, name "Filename", with default value "DataGridReactive".
* A new function was created to handle the name properly

### Test Steps
1. Add a filename in the ContextMenu option "Export to Excel"
2. Validate that the file exported has the filename + extension passed in OutSystems
3. Leave the filename field empty
4. Validate that the output file has the filename 'DataGridReactive' + extension.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [x] requires new sample page in OutSystems (if so, provide a module with changes)

