### PR TITLE
RGRIDT-871: Change display values was being called in a wrong place

### DIFF
--- a/code/src/WijmoProvider/Columns/DropdownColumn.ts
+++ b/code/src/WijmoProvider/Columns/DropdownColumn.ts
@@ -16,9 +16,8 @@ namespace WijmoProvider.Column {
                 )
             );
             this.config.dataMap = new wijmo.grid.DataMap([], 'key', 'text');
-            this._columnEvents = new OSFramework.Event.Column.ColumnEventsManager(
-                this
-            );
+            this._columnEvents =
+                new OSFramework.Event.Column.ColumnEventsManager(this);
         }
 
         private _parentCellValueChangeHandler(
@@ -83,21 +82,24 @@ namespace WijmoProvider.Column {
                 providerConfig.visible = this._getVisibility();
 
                 wijmo.copy(this.provider, providerConfig);
-                if (this.config.parentBinding) {
-                    this.changeDisplayValues();
-                }
             } else {
                 console.log('applyConfigs - Column needs to be build');
             }
         }
 
         public build(): void {
-            (this.config
-                .dataMap as wijmo.grid.DataMap).collectionView.sourceCollection = this.config.dropdownOptions;
+            (
+                this.config.dataMap as wijmo.grid.DataMap
+            ).collectionView.sourceCollection = this.config.dropdownOptions;
             this.config.dataMapEditor = wijmo.grid.DataMapEditor.DropDownList;
 
             super.build();
+
+            if (this.config.parentBinding) {
+                this.changeDisplayValues();
+            }
         }
+
         public changeDisplayValues(): void {
             const dataMap = this.config.dataMap;
             const values = dataMap.collectionView.items;


### PR DESCRIPTION
[Sample page](url)

### What was happening
* Dropdown column dependency was only work if we changed parameters.

### What was done
* Changed where displayValues is called.

### Test Steps
1. 


### Screenshots
(prefer animated gif)


### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

