### PR TITLE
RGRIDT-874: Fixing add rows with calculated columns

### DIFF
--- a/code/src/WijmoProvider/Features/ColumnFilter.ts
+++ b/code/src/WijmoProvider/Features/ColumnFilter.ts
@@ -25,7 +25,8 @@ namespace WijmoProvider.Feature {
         implements
             OSFramework.Feature.IColumnFilter,
             OSFramework.Interface.IBuilder,
-            OSFramework.Interface.IDisposable {
+            OSFramework.Interface.IDisposable
+    {
         private _enabled: boolean;
         private _filter: wijmo.grid.filter.FlexGridFilter;
         private _grid: WijmoProvider.Grid.IGridWijmo;
@@ -61,7 +62,11 @@ namespace WijmoProvider.Feature {
         }
 
         public get isGridFiltered(): boolean {
-            return JSON.parse(this._filter.filterDefinition).filters.length > 0;
+            return (
+                JSON.parse(this._filter.filterDefinition).filter(
+                    (x) => x.filterType !== 0
+                ).filters.length > 0
+            );
         }
         public activate(columID: string): void {
             const column = GridAPI.ColumnManager.GetColumnById(columID);
@@ -86,12 +91,13 @@ namespace WijmoProvider.Feature {
                 this.validateAction.bind(this)
             );
 
-            const dateOperators = wijmo.culture.FlexGridFilter.numberOperators.filter(
-                function (item) {
+            const dateOperators =
+                wijmo.culture.FlexGridFilter.numberOperators.filter(function (
+                    item
+                ) {
                     //Removing item "Does not Equal"
                     return item.op !== 1;
-                }
-            );
+                });
 
             wijmo.culture.FlexGridFilter.dateOperators = dateOperators;
 


### PR DESCRIPTION
This PR is for fixing add rows with calculated columns

### What was happening
* It was not possible to add rows when there was a calculated column

### What was done
* Changed isGridFiltered method.


### Screenshots
(prefer animated gif)


### Checklist
* [x] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

