### PR TITLE
RGRIDT-875: Adding method to Grid API

### DIFF
--- a/code/src/GridAPI/GridManager.ts
+++ b/code/src/GridAPI/GridManager.ts
@@ -94,6 +94,16 @@ namespace GridAPI.GridManager {
     }
 
     /**
+     * Function that returns all Ids of the grids in the page.
+     *
+     * @export
+     * @returns {*}  {Map<string, OSFramework.Grid.IGrid>}
+     */
+    export function GetAllGridIdsInPage(): Array<string> {
+        return Array.from(gridMap.keys());
+    }
+
+    /**
      * Function that gets the instance of the current active grid. The active grid, is always the last (existing) grid that was created in the page.
      *
      * @export


### PR DESCRIPTION
This PR is to add a method to return all of the IDs of the grid in the page.

### What was happening
* There was no way to obtain programmatically the IDs of the Grids in the page

### What was done
* Added a method to return the IDs from the Maps map.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

