### PR TITLE
RGRIDT-877 - Possibility to have custom column header tooltips

### DIFF
--- a/code/src/GridAPI/ColumnManager.ts
+++ b/code/src/GridAPI/ColumnManager.ts
@@ -52,9 +52,6 @@ namespace GridAPI.ColumnManager {
                 );
             }
 
-            if (jsonConfigs.headerTooltip) {
-                //
-            }
             output = true;
         }
 

--- a/code/src/GridAPI/ColumnManager.ts
+++ b/code/src/GridAPI/ColumnManager.ts
@@ -51,6 +51,10 @@ namespace GridAPI.ColumnManager {
                     jsonEditorConfigs.conditionalFormat
                 );
             }
+
+            if (jsonConfigs.headerTooltip) {
+                //
+            }
             output = true;
         }
 

--- a/code/src/OSFramework/Configuration/Column/ColumnConfig.ts
+++ b/code/src/OSFramework/Configuration/Column/ColumnConfig.ts
@@ -24,6 +24,7 @@ namespace OSFramework.Configuration.Column {
         public format: string;
         public genericColumnId: string;
         public header: string;
+        public headerTooltip: string;
         public isMandatory: boolean;
         public multiLine: boolean;
         public required: boolean;

--- a/code/src/OSFramework/Configuration/Column/ColumnConfigGroup.ts
+++ b/code/src/OSFramework/Configuration/Column/ColumnConfigGroup.ts
@@ -19,6 +19,7 @@ namespace OSFramework.Configuration.Column {
         public format: string;
         public genericColumnId: string;
         public header: string;
+        public headerTooltip: string;
         public isCollapsed: boolean;
         public isMandatory: boolean;
         public required: boolean;

--- a/code/src/OSFramework/Configuration/IConfigurationColumn.ts
+++ b/code/src/OSFramework/Configuration/IConfigurationColumn.ts
@@ -32,6 +32,8 @@ namespace OSFramework.Configuration {
         genericColumnId: string;
         /** The header of a column */
         header: string;
+        /** String to display on the column header tooltip */
+        headerTooltip: string;
         /** Wether or not column is mandatory*/
         isMandatory: boolean;
         /** Defines when the column can or not be empty */

--- a/code/src/OSFramework/Feature/ExposedFeatures.ts
+++ b/code/src/OSFramework/Feature/ExposedFeatures.ts
@@ -1,7 +1,6 @@
 namespace OSFramework.Feature {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     export class ExposedFeatures {
-
         public cellData: ICellData;
         public calculatedField: ICalculatedField;
         public cellStyle: ICellStyle;

--- a/code/src/OSFramework/Feature/IValidationMark.ts
+++ b/code/src/OSFramework/Feature/IValidationMark.ts
@@ -13,7 +13,10 @@ namespace OSFramework.Feature {
             isValid: boolean,
             errorMessage: string
         ): void;
-        validateCell(rowNumber: number, column: OSFramework.Column.IColumn): void;
+        validateCell(
+            rowNumber: number,
+            column: OSFramework.Column.IColumn
+        ): void;
         validateRow(rowNumber: number): void;
         // clearByRow(row: number): void;
     }

--- a/code/src/WijmoProvider/Columns/DropdownColumn.ts
+++ b/code/src/WijmoProvider/Columns/DropdownColumn.ts
@@ -17,8 +17,9 @@ namespace WijmoProvider.Column {
                 )
             );
             this.config.dataMap = new wijmo.grid.DataMap([], 'key', 'text');
-            this._columnEvents =
-                new OSFramework.Event.Column.ColumnEventsManager(this);
+            this._columnEvents = new OSFramework.Event.Column.ColumnEventsManager(
+                this
+            );
             this._handlerAdded = false;
         }
 
@@ -105,9 +106,8 @@ namespace WijmoProvider.Column {
         }
 
         public build(): void {
-            (
-                this.config.dataMap as wijmo.grid.DataMap
-            ).collectionView.sourceCollection = this.config.dropdownOptions;
+            (this.config
+                .dataMap as wijmo.grid.DataMap).collectionView.sourceCollection = this.config.dropdownOptions;
             this.config.dataMapEditor = wijmo.grid.DataMapEditor.DropDownList;
 
             super.build();

--- a/code/src/WijmoProvider/Features/ColumnFilter.ts
+++ b/code/src/WijmoProvider/Features/ColumnFilter.ts
@@ -25,8 +25,7 @@ namespace WijmoProvider.Feature {
         implements
             OSFramework.Feature.IColumnFilter,
             OSFramework.Interface.IBuilder,
-            OSFramework.Interface.IDisposable
-    {
+            OSFramework.Interface.IDisposable {
         private _enabled: boolean;
         private _filter: wijmo.grid.filter.FlexGridFilter;
         private _grid: WijmoProvider.Grid.IGridWijmo;
@@ -91,13 +90,12 @@ namespace WijmoProvider.Feature {
                 this.validateAction.bind(this)
             );
 
-            const dateOperators =
-                wijmo.culture.FlexGridFilter.numberOperators.filter(function (
-                    item
-                ) {
+            const dateOperators = wijmo.culture.FlexGridFilter.numberOperators.filter(
+                function (item) {
                     //Removing item "Does not Equal"
                     return item.op !== 1;
-                });
+                }
+            );
 
             wijmo.culture.FlexGridFilter.dateOperators = dateOperators;
 

--- a/code/src/WijmoProvider/Features/ToolTip.ts
+++ b/code/src/WijmoProvider/Features/ToolTip.ts
@@ -58,7 +58,6 @@ namespace WijmoProvider.Feature {
             } else if (ht.cellType === wijmo.grid.CellType.ColumnHeader) {
                 const rendered = this._grid.getColumn(ht.getColumn().binding)
                     .config;
-                this._grid.provider.columns[ht.col] || {};
 
                 if (_currTarget && rendered.headerTooltip) {
                     if (document.getElementById(rendered.headerTooltip)) {

--- a/code/src/WijmoProvider/Features/ToolTip.ts
+++ b/code/src/WijmoProvider/Features/ToolTip.ts
@@ -62,6 +62,8 @@ namespace WijmoProvider.Feature {
 
                 if (_currTarget && rendered.headerTooltip) {
                     if (document.getElementById(rendered.headerTooltip)) {
+                        // If headerTooltip is an Id of an Element, it should be manipulated to be a selector.
+                        // setTooltip() wijmo method allows us to render the content of another element using its id
                         rendered.headerTooltip = '#' + rendered.headerTooltip;
                     }
                     this._setHeaderTooltip(_currTarget, rendered.headerTooltip);

--- a/code/src/WijmoProvider/Features/ToolTip.ts
+++ b/code/src/WijmoProvider/Features/ToolTip.ts
@@ -56,23 +56,32 @@ namespace WijmoProvider.Feature {
                     );
                 }
             } else if (ht.cellType === wijmo.grid.CellType.ColumnHeader) {
-                if (
+                const rendered = this._grid.getColumn(ht.getColumn().binding)
+                    .config;
+                this._grid.provider.columns[ht.col] || {};
+
+                if (_currTarget && rendered.headerTooltip) {
+                    if (document.getElementById(rendered.headerTooltip)) {
+                        rendered.headerTooltip = '#' + rendered.headerTooltip;
+                    }
+                    this._setHeaderTooltip(_currTarget, rendered.headerTooltip);
+                } else if (
                     _currTarget &&
                     _currTarget.innerText !== undefined &&
                     _currTarget.innerText !== ''
                 ) {
-                    //Make sure to reset the cssClass for the tooltip
-                    this._toolTipClass(false);
-                    this._toolTip.setTooltip(
-                        _currTarget,
-                        _currTarget.innerText
-                    );
+                    this._setHeaderTooltip(_currTarget, _currTarget.innerText);
                 }
             }
         }
-
         private _onMouseOut(/*e: Event*/): void {
             this._toolTip.hide();
+        }
+
+        private _setHeaderTooltip(element: HTMLElement, content: string): void {
+            //Make sure to reset the cssClass for the tooltip
+            this._toolTipClass(false);
+            this._toolTip.setTooltip(element, content);
         }
 
         private _setToolTip(cell: Element): void {

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -3,8 +3,7 @@ namespace WijmoProvider.Feature {
     export class ValidationMark
         implements
             OSFramework.Feature.IValidationMark,
-            OSFramework.Interface.IBuilder
-    {
+            OSFramework.Interface.IBuilder {
         private _grid: WijmoProvider.Grid.IGridWijmo;
         /** Internal label for the validation marks */
         private readonly _internalLabel = '__validationMarkFeature';
@@ -413,8 +412,8 @@ namespace WijmoProvider.Feature {
             isValid: boolean,
             errorMessage: string
         ): void {
-            const column =
-                GridAPI.ColumnManager.GetColumnById(columnWidgetID).provider;
+            const column = GridAPI.ColumnManager.GetColumnById(columnWidgetID)
+                .provider;
 
             // Sets the validation map by matching the binding of the columns with the boolean that indicates whether theres is an invalid cell in the row or not.
             this.getMetadataByRowNumber(rowNumber).validation.set(


### PR DESCRIPTION

### What was happening
* The Column header tooltips were static, displaying the cell content.

### What was done
* Add a parameter to the column config, where the developer can customize the tooltip content.

### Test Steps
1. Fill the new Column Parameter with some text;
2. Check the tooltip hovering the column header; 
3. Fill the new Column Parameter on another Column with html;
4. Check the tooltip content, it shouldn't process the html (security);
5. Fill the new Column Parameter on another Column with an id;
6. Check the tooltip content, it should clone the content of the target id;

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems
* [x] requires new sample page in OutSystems

