### PR TITLE
RGRIDT-891 - Removing osrowmetadata in the action column click event

### DIFF
--- a/code/src/GridAPI/ContextMenu.ts
+++ b/code/src/GridAPI/ContextMenu.ts
@@ -17,9 +17,8 @@ namespace GridAPI.ContextMenu {
     ): string {
         //Try to find in DOM only if not present on Map
         if (lookUpDOM && !_menuItemsToGridId.has(menuItemId)) {
-            const menuOptionElement = OSFramework.Helper.GetElementByUniqueId(
-                menuItemId
-            );
+            const menuOptionElement =
+                OSFramework.Helper.GetElementByUniqueId(menuItemId);
             const grid = OSFramework.Helper.GetClosestGrid(menuOptionElement);
 
             if (grid) {

--- a/code/src/WijmoProvider/Columns/ActionColumn.ts
+++ b/code/src/WijmoProvider/Columns/ActionColumn.ts
@@ -42,10 +42,12 @@ namespace WijmoProvider.Column {
                         ? this.config.binding.substr(1)
                         : undefined,
                 click: (e, ctx) => {
+                    if (ctx.item['__osRowMetada']) {
+                        delete ctx.item['__osRowMetada'];
+                    }
                     this._columnEvents.trigger(
                         OSFramework.Event.Column.ColumnEventType.ActionClick,
                         JSON.stringify(
-                            //TODO: [RGRIDT-637] refactor this code.
                             this.grid.isSingleEntity
                                 ? OSFramework.Helper.Flatten(ctx.item)
                                 : ctx.item

--- a/jobs/tests/features.txt
+++ b/jobs/tests/features.txt
@@ -1,0 +1,1 @@
+actionColumn

--- a/jobs/tests/features.txt
+++ b/jobs/tests/features.txt
@@ -1,1 +1,1 @@
-actionColumn
+@actionColumn


### PR DESCRIPTION
This PR is to remove osrowmetadata in the action column click event

### What was happening 
* osrowmetadata in the action column click event was being added to the event data

### What was done
* osrowmetadata in the action column click event was removed to the event data

### Test Steps
1. Open Sample
2. Click the details cell in any of the rows
3. Check the Raw data in Test Results and see that osrowmetadata is not present


### Screenshots
Before:
![image](https://user-images.githubusercontent.com/22915981/124606367-bc2b9200-de64-11eb-9b61-1f421ffa986d.png)

After:
![image](https://user-images.githubusercontent.com/22915981/124606281-a4eca480-de64-11eb-8768-1e7bef2049b9.png)


### Checklist
* [X] tested locally
* [ ] documented the code
* [X] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

