### PR TITLE
RGRIDT-894: Fixing GetRowData

### DIFF
--- a/code/src/GridAPI/Rows.ts
+++ b/code/src/GridAPI/Rows.ts
@@ -42,6 +42,25 @@ namespace GridAPI.Rows {
     }
 
     /**
+     * Function that will get data from a specific row
+     *
+     * @export
+     * @param {string} gridID ID of the Grid where the change will occur.
+     * @param {number} rowNumber Number of the row in data will be retrieved.
+     * @returns {*}  {string} Resulting code and message in JSON format
+     */
+    export function GetRowData(gridID: string, rowNumber: number): string {
+        const grid = GridManager.GetGridById(gridID);
+        let output = '';
+
+        if (grid !== undefined) {
+            output = grid.features.rows.getRowData(rowNumber);
+        }
+
+        return output;
+    }
+
+    /**
      * Remove all CSS classes from a specific row on the grid.
      *
      * @param {string} gridID ID of the Grid where the change will occur.

--- a/code/src/GridAPI/Rows.ts
+++ b/code/src/GridAPI/Rows.ts
@@ -54,7 +54,7 @@ namespace GridAPI.Rows {
         let output = '';
 
         if (grid !== undefined) {
-            output = grid.features.rows.getRowData(rowNumber);
+            output = JSON.stringify(grid.features.rows.getRowData(rowNumber));
         }
 
         return output;

--- a/code/src/OSFramework/Feature/IRows.ts
+++ b/code/src/OSFramework/Feature/IRows.ts
@@ -17,6 +17,10 @@ namespace OSFramework.Feature {
          */
         clear(): void;
         /**
+         * Get data from a specific row.
+         */
+        getRowData(rowNumber: number): string;
+        /**
          * Clear all classes from a specific row.
          */
         removeAllClasses(rowNumber: number): void;

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -267,6 +267,7 @@ namespace WijmoProvider.Feature {
             ) as CssClassInfo;
         }
 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getRowData(rowNumber: number): any {
             return this._grid.isSingleEntity
                 ? OSFramework.Helper.Flatten(

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -269,9 +269,11 @@ namespace WijmoProvider.Feature {
 
         public getRowData(rowNumber: number): string {
             return JSON.stringify(
-                OSFramework.Helper.Flatten(
-                    this._grid.provider.rows[rowNumber].dataItem
-                )
+                this._grid.isSingleEntity
+                    ? OSFramework.Helper.Flatten(
+                          this._grid.provider.rows[rowNumber].dataItem
+                      )
+                    : this._grid.provider.rows[rowNumber].dataItem
             );
         }
 

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -267,7 +267,7 @@ namespace WijmoProvider.Feature {
             ) as CssClassInfo;
         }
 
-        public getRowData(rowNumber: number): string {
+        public getRowData(rowNumber: number): any {
             return this._grid.isSingleEntity
                 ? OSFramework.Helper.Flatten(
                       this._grid.provider.rows[rowNumber].dataItem

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -268,13 +268,11 @@ namespace WijmoProvider.Feature {
         }
 
         public getRowData(rowNumber: number): string {
-            return JSON.stringify(
-                this._grid.isSingleEntity
-                    ? OSFramework.Helper.Flatten(
-                          this._grid.provider.rows[rowNumber].dataItem
-                      )
-                    : this._grid.provider.rows[rowNumber].dataItem
-            );
+            return this._grid.isSingleEntity
+                ? OSFramework.Helper.Flatten(
+                      this._grid.provider.rows[rowNumber].dataItem
+                  )
+                : this._grid.provider.rows[rowNumber].dataItem;
         }
 
         /**

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -78,7 +78,8 @@ namespace WijmoProvider.Feature {
     }
 
     export class Rows
-        implements OSFramework.Interface.IBuilder, OSFramework.Feature.IRows {
+        implements OSFramework.Interface.IBuilder, OSFramework.Feature.IRows
+    {
         private _grid: WijmoProvider.Grid.IGridWijmo;
 
         /** This is going to be used as a label for the css classes saved on the metadata of the Row */
@@ -266,6 +267,14 @@ namespace WijmoProvider.Feature {
             ) as CssClassInfo;
         }
 
+        public getRowData(rowNumber: number): string {
+            return JSON.stringify(
+                OSFramework.Helper.Flatten(
+                    this._grid.provider.rows[rowNumber].dataItem
+                )
+            );
+        }
+
         /**
          * Indicates if a specific row has any metadata associated to the cssClasses.
          * @param rowNumber Number of the row to check if there is any metadata associated to the cssClasses.
@@ -323,8 +332,9 @@ namespace WijmoProvider.Feature {
             const expectedRowCount =
                 this._getRowsCount() -
                 this._grid.features.selection.getSelectedRowsCountByCellRange();
-            const selRanges = (this._grid.features
-                .selection as IProviderSelection).getProviderAllSelections();
+            const selRanges = (
+                this._grid.features.selection as IProviderSelection
+            ).getProviderAllSelections();
 
             // In case of Undo action, the user will not need to click on the grid to undo.
             providerGrid.focus();

--- a/jobs/tests/features.txt
+++ b/jobs/tests/features.txt
@@ -1,1 +1,0 @@
-@actionColumn


### PR DESCRIPTION
This PR fixes GetRowData when Grid is Single Entity.

### What was happening
* GetRowData was not working properly on grids with single entity.

### What was done
* Created method that check is grid is single entity or not and returns dataItem from row.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

