### PR TITLE
RGRIDT-919: Fixing dropdown on cell value change

### DIFF
--- a/code/src/WijmoProvider/Columns/DropdownColumn.ts
+++ b/code/src/WijmoProvider/Columns/DropdownColumn.ts
@@ -33,7 +33,8 @@ namespace WijmoProvider.Column {
             if (oldValue !== newValue) {
                 const currentValue = this.grid.provider.getCellData(
                     rowNumber,
-                    this.provider.index
+                    this.provider.index,
+                    true
                 );
 
                 this.grid.features.dirtyMark.saveOriginalValue(
@@ -46,7 +47,7 @@ namespace WijmoProvider.Column {
                     '',
                     true
                 );
-                this.grid.features.validationMark.validateRow(rowNumber);
+                this.grid.features.validationMark.validateCell(rowNumber, this);
 
                 const column = this.grid.getColumn(columnID);
 
@@ -64,17 +65,20 @@ namespace WijmoProvider.Column {
         }
 
         private _parentHandler() {
-            const column = this.grid.getColumn(this.config.parentBinding);
+            if (this.config.parentBinding) {
+                const column = this.grid.getColumn(this.config.parentBinding);
 
-            if (column) {
-                // set child column to non mandatory, so we can set it to blank when parent changes value
-                this.provider.isRequired = false;
+                if (column) {
+                    // set child column to non mandatory, so we can set it to blank when parent changes value
+                    this.provider.isRequired = false;
 
-                // on parent cell change subscription, to set child cell's to blank
-                column.columnEvents.addHandler(
-                    OSFramework.Event.Column.ColumnEventType.OnCellValueChange,
-                    this._parentCellValueChangeHandler.bind(this)
-                );
+                    // on parent cell change subscription, to set child cell's to blank
+                    column.columnEvents.addHandler(
+                        OSFramework.Event.Column.ColumnEventType
+                            .OnCellValueChange,
+                        this._parentCellValueChangeHandler.bind(this)
+                    );
+                }
             }
         }
 
@@ -116,10 +120,13 @@ namespace WijmoProvider.Column {
                 this.config.dropdownOptions &&
                 this.config.dropdownOptions.length > 0
             ) {
-                this.changeDisplayValues();
-                if (!this._handlerAdded) {
-                    this._parentHandler();
-                    this._handlerAdded = true;
+                // eslint-disable-next-line no-extra-boolean-cast
+                if (!!this.config.parentBinding) {
+                    this.changeDisplayValues();
+                    if (!this._handlerAdded) {
+                        this._parentHandler();
+                        this._handlerAdded = true;
+                    }
                 }
             }
         }
@@ -128,9 +135,12 @@ namespace WijmoProvider.Column {
             const dataMap = this.config.dataMap;
             const values = dataMap.collectionView.items;
 
-            const column = this.grid.getColumn(this.config.parentBinding);
+            const parentColumn = this.grid.getColumn(this.config.parentBinding);
 
-            if (column) {
+            if (
+                parentColumn &&
+                parentColumn.columnType === OSFramework.Enum.ColumnType.Dropdown
+            ) {
                 // override getDisplayValues method to get values that
                 // correspond to the parent
                 dataMap.getDisplayValues = (dataItem) => {
@@ -169,7 +179,9 @@ namespace WijmoProvider.Column {
                     this.config.dropdownOptions = values;
                     dataMap.collectionView.sourceCollection = values;
                     dataMap.collectionView.refresh();
-                    if (this.config.parentBinding) {
+
+                    // eslint-disable-next-line no-extra-boolean-cast
+                    if (!!this.config.parentBinding) {
                         this.changeDisplayValues();
 
                         if (!this._handlerAdded) {


### PR DESCRIPTION


[Sample page](url)

### What was happening
* Whenever we changed values on parent dropdowns sequentially, an error was thrown on console. This was happening because we were returning unformatted data from cell.
![dropdownValuechange](https://user-images.githubusercontent.com/3113318/125601328-f763a7e1-754a-4bd9-9ebb-c8df695c3e77.gif)


### What was done
* Adjusted wijmo.getCellData method to return formatted values.


### Screenshots
(prefer animated gif)


### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

