### PR TITLE
RGRIDT-923: Improving the way that osRowMetadata is removed

### DIFF
--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -107,6 +107,7 @@ namespace OSFramework.Grid {
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         protected _ds: Array<any>;
         protected _metadata: JSON;
+        protected _parentGrid: IGrid;
 
         constructor() {
             // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
@@ -117,7 +118,11 @@ namespace OSFramework.Grid {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
         protected _getChangesString(itemsChanged: any): string {
-            let tempArray = itemsChanged.map((p) => _.cloneDeep(p));
+            let tempArray = itemsChanged.map((p) => {
+                const clonedDataItem = _.cloneDeep(p);
+                this._parentGrid.rowMetadata.clear(clonedDataItem);
+                return clonedDataItem;
+            });
 
             //In-place convert data to Outsystems Format
             ToOSFormat(this._convertions, tempArray);
@@ -156,6 +161,16 @@ namespace OSFramework.Grid {
 
         public get isSingleEntity(): boolean {
             return this._isSingleEntity;
+        }
+
+        public get parentGrid(): IGrid {
+            return this._parentGrid;
+        }
+
+        public set parentGrid(grid: IGrid) {
+            if (this._parentGrid === undefined) {
+                this._parentGrid = grid;
+            }
         }
 
         public addRow(position?: number, data?: JSON[]): void {

--- a/code/src/OSFramework/Grid/AbstractGrid.ts
+++ b/code/src/OSFramework/Grid/AbstractGrid.ts
@@ -37,6 +37,9 @@ namespace OSFramework.Grid {
             this._gridEvents = new Event.Grid.GridEventsManager(this);
             this._validatingAction = new Event.Grid.ValidatingAction();
 
+            //The purpose here is to set the datasource parent grid.
+            this._dataSource.parentGrid = this;
+
             console.log(`Constructor grid '${this.uniqueId}'`);
         }
 

--- a/code/src/OSFramework/Interface/IDataSource.ts
+++ b/code/src/OSFramework/Interface/IDataSource.ts
@@ -13,6 +13,15 @@ namespace OSFramework.Grid {
          */
         isSingleEntity: boolean;
         /**
+         * Identifies the parent grid of this data source.
+         * This way, when formating data to be exported the removal of the
+         * metadata can be done by the object that knows it.
+         *
+         * @type {IGrid}
+         * @memberof IDataSource
+         */
+        parentGrid: IGrid;
+        /**
          * Add row to an specific position on the DataSource
          * @param position index position (0-based)
          * @param data The array of items to be inserted

--- a/code/src/WijmoProvider/Columns/ActionColumn.ts
+++ b/code/src/WijmoProvider/Columns/ActionColumn.ts
@@ -42,15 +42,16 @@ namespace WijmoProvider.Column {
                         ? this.config.binding.substr(1)
                         : undefined,
                 click: (e, ctx) => {
-                    if (ctx.item['__osRowMetada']) {
-                        delete ctx.item['__osRowMetada'];
-                    }
+                    //Let's clone the line, since we will be removing the metadata info from it.
+                    const clonedDataItem = _.cloneDeep(ctx.item);
+                    this.grid.rowMetadata.clear(clonedDataItem);
+
                     this._columnEvents.trigger(
                         OSFramework.Event.Column.ColumnEventType.ActionClick,
                         JSON.stringify(
                             this.grid.isSingleEntity
-                                ? OSFramework.Helper.Flatten(ctx.item)
-                                : ctx.item
+                                ? OSFramework.Helper.Flatten(clonedDataItem)
+                                : clonedDataItem
                         )
                     );
                 }

--- a/code/src/WijmoProvider/Grid/RowMetadata.ts
+++ b/code/src/WijmoProvider/Grid/RowMetadata.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace WijmoProvider.Grid {
     export class RowMetadata implements OSFramework.Interface.IRowMetadata {
-        private readonly _extraData = '__osRowMetada';
+        private readonly _extraData = '__osRowMetadata';
         private _grid: wijmo.grid.FlexGrid;
         private _itemsSource: wijmo.collections.CollectionView;
 


### PR DESCRIPTION
This PR is for improving the way metadata is being removed from the lines when they are being returned to the OutSystems side.

### What was happening
* When the action column link was clicked, the osRowMetadata was being removed from the actual line, causing the dirty marks, errors and other css classes to be removed in the line next refresh (i.e. after scroll).
* The metadata information, was not being removed when the API GetChangedLines was called. 

### What was done
* The action column, now performs a clone of the line before removing the metadata and returning it
* The action column, additionally invokes the method `clear` of the `RowMetadata` object that knows how to remove the metadata.
* The data source (AbstractDataSource), is now aware of who the parent grid is, and in the method `_getChangesString` now invokes the `clear` method  of the object `RowMetadata`.

### Test Steps
1. Go to a grid that is editable and has an Action column
2. Make some changes in one of the lines
3. Notice that the dirty marks should appear
4. Click on the action column link
5. Scroll in the data grid until the line disappears
6. Scroll back to the line
7. Notice that the dirty mark is still there
-----
1. Go to a grid that is editable
2. Make some changes in one of the lines
3. Notice that the dirty marks should appear
4. Click to Save Changes (or any other button that invokes the API GetChangedLines
5. Validate that the return value of the GetChangedLines, does not have any property named __osRowMetadata


### Checklist
* [x] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

