### PR TITLE
RGRIDT-852: Fixing dirty mark for dropdown and date columns

### DIFF
--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -3,7 +3,8 @@ namespace WijmoProvider.Feature {
     export class DirtyMark
         implements
             OSFramework.Feature.IDirtyMark,
-            OSFramework.Interface.IBuilder {
+            OSFramework.Interface.IBuilder
+    {
         private _grid: WijmoProvider.Grid.IGridWijmo;
         private readonly _internalLabel = '__dirtyMarkFeature';
         private _metadata: OSFramework.Interface.IRowMetadata;
@@ -53,7 +54,10 @@ namespace WijmoProvider.Feature {
             const grid = this._grid.provider;
             if (this.hasMetadata(row)) {
                 const binding = grid.getColumn(col).binding;
-                const cellValue = grid.getCellData(row, col, false);
+                const columnType = this._grid.getColumn(binding)?.columnType;
+                const isDropdown =
+                    columnType === OSFramework.Enum.ColumnType.Dropdown;
+                const cellValue = grid.getCellData(row, col, isDropdown); // on dropdown columns we want formatted value
                 const metadata = this.getMetadata(row);
 
                 //If the cell isNew we want to have the dirty mark
@@ -72,7 +76,8 @@ namespace WijmoProvider.Feature {
                         //Even when converted to String because after edition the cells from the Dropdown Columns will have the value in string format and before edition the value of those same cells can be integers (number identifiers).
                         return (
                             originalValue !== cellValue &&
-                            originalValue.toString() !== cellValue
+                            originalValue.toString() !== cellValue &&
+                            originalValue.toString() !== cellValue.toString() // compare date objects as well
                         );
                     }
                 }
@@ -86,10 +91,14 @@ namespace WijmoProvider.Feature {
                 let notDirtyCells = 0;
 
                 for (const k of metadata.originalValues.keys()) {
+                    const columnType = this._grid.getColumn(k)?.columnType;
+                    const isDropdown =
+                        columnType === OSFramework.Enum.ColumnType.Dropdown;
+                    // on dropdown columns we want formatted value
                     const cellValue = this._grid.provider.getCellData(
                         row,
                         k,
-                        false
+                        isDropdown
                     );
                     const originalValue = metadata.originalValues.get(k);
 
@@ -107,7 +116,8 @@ namespace WijmoProvider.Feature {
                         //Even when converted to String because after edition the cells from the Dropdown Columns will have the value in string format and before edition the value of those same cells can be integers (number identifiers).
                         if (
                             originalValue === cellValue ||
-                            originalValue.toString() === cellValue
+                            originalValue.toString() === cellValue ||
+                            originalValue.toString() === cellValue.toString() // compare date objects as well
                         ) {
                             //Add 1 to the notDirtyCells
                             notDirtyCells++;


### PR DESCRIPTION
### What was happening
* There was a bug that when you selected the same value on a dropdown column, the dirty mark appeared. The same happened for date columns, where altering the original value and selecting the original value made the dirty mark appear.

![dropdownbug](https://user-images.githubusercontent.com/3113318/126208732-5537b198-e03a-4ec8-93aa-0f5386aa70c3.gif)

![datebug](https://user-images.githubusercontent.com/3113318/126208989-7c3eb6d1-2cdb-4f57-a37a-d6688e56627f.gif)

### What was done
* Created a flag to see if the value was from a dropdown column and added one more comparison for date columns.

![dropdownbugfix](https://user-images.githubusercontent.com/3113318/126208884-d61c77ee-2157-4f75-8d37-2deb383d8cd3.gif)

![datebugfix](https://user-images.githubusercontent.com/3113318/126209004-2e097500-cfa3-4a4e-9843-b026cb3743c5.gif)


### Test Steps
1. 


### Screenshots
(prefer animated gif)


### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

