### PR TITLE
Removing header alt

### DIFF
--- a/code/styles/Grid.css
+++ b/code/styles/Grid.css
@@ -259,8 +259,7 @@
 
 .wj-cell.wj-state-invalid.wj-header.wj-alt:not(.wj-state-multi-selected),
 .wj-cell.wj-state-invalid.wj-header.wj-header-alt:not(.wj-state-multi-selected),
-.wj-cell.wj-alt,
-.wj-cell.wj-header-alt {
+.wj-cell.wj-alt {
     background: var(--datagrid-cell-background-alt);
 }
 


### PR DESCRIPTION
This PR is for adjusting header color



### What was happening
* With group columns, the column header had alternative color.

### What was done
* Removed alt color from column headers.



### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

