### PR TITLE
RGRIDT-973: Set rows valid after deletion

### DIFF
--- a/code/src/GridAPI/GridManager.ts
+++ b/code/src/GridAPI/GridManager.ts
@@ -233,7 +233,7 @@ namespace GridAPI.GridManager {
         const grid = GetGridById(gridID);
         const output = setDataInGrid(grid, data);
 
-        PerformanceAPI.SetMark('SetGridData-end');
+        PerformanceAPI.SetMark('GridManager.SetGridData-end');
         PerformanceAPI.GetMeasure(
             '@datagrid-GridManager.SetGridData',
             'GridManager.SetGridData',

--- a/code/src/OSFramework/Feature/IValidationMark.ts
+++ b/code/src/OSFramework/Feature/IValidationMark.ts
@@ -7,13 +7,13 @@ namespace OSFramework.Feature {
         errorMessage(rowNumber: number, binding: string): string;
         isInvalid(rowNumber: number, binding: string): boolean;
         isInvalidRow(row: any): boolean;
-        setRowStatus(rowNumber: number, isValid: boolean): void;
-        setStatus(
+        setCellStatus(
             rowNumber: number,
             columnID: string,
             isValid: boolean,
             errorMessage: string
         ): void;
+        setRowStatus(rowNumber: number, isValid: boolean): void;
         validateCell(
             rowNumber: number,
             column: OSFramework.Column.IColumn

--- a/code/src/OSFramework/Feature/IValidationMark.ts
+++ b/code/src/OSFramework/Feature/IValidationMark.ts
@@ -7,6 +7,7 @@ namespace OSFramework.Feature {
         errorMessage(rowNumber: number, binding: string): string;
         isInvalid(rowNumber: number, binding: string): boolean;
         isInvalidRow(row: any): boolean;
+        setRowStatus(rowNumber: number, isValid: boolean): void;
         setStatus(
             rowNumber: number,
             columnID: string,

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -356,6 +356,11 @@ namespace WijmoProvider.Feature {
                         );
                         // Remove the data item from the editable collection view.
                         dataSource.remove(providerGrid.rows[row].dataItem);
+                        // Removed rows should be valid
+                        this._grid.features.validationMark.setRowStatus(
+                            row,
+                            true
+                        );
                     }
                 });
             });

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -3,7 +3,8 @@ namespace WijmoProvider.Feature {
     export class ValidationMark
         implements
             OSFramework.Feature.IValidationMark,
-            OSFramework.Interface.IBuilder {
+            OSFramework.Interface.IBuilder
+    {
         private _grid: WijmoProvider.Grid.IGridWijmo;
         /** Internal label for the validation marks */
         private readonly _internalLabel = '__validationMarkFeature';
@@ -399,6 +400,11 @@ namespace WijmoProvider.Feature {
             );
         }
 
+        public setRowStatus(rowNumber: number, isValid: boolean): void {
+            // set invalidRows with row number and flag that checks if status isValid and if there are invalid values on metadata
+            this._setInvalidRows(rowNumber, isValid);
+        }
+
         /**
          * Used to validate a cell by defining its metadata with a state that indicates if it is valid or not.
          * @param rowNumber Number of the row in which the action of validation should be triggered.
@@ -412,8 +418,8 @@ namespace WijmoProvider.Feature {
             isValid: boolean,
             errorMessage: string
         ): void {
-            const column = GridAPI.ColumnManager.GetColumnById(columnWidgetID)
-                .provider;
+            const column =
+                GridAPI.ColumnManager.GetColumnById(columnWidgetID).provider;
 
             // Sets the validation map by matching the binding of the columns with the boolean that indicates whether theres is an invalid cell in the row or not.
             this.getMetadataByRowNumber(rowNumber).validation.set(
@@ -441,6 +447,25 @@ namespace WijmoProvider.Feature {
             this._grid.provider.invalidate();
         }
 
+        public validateCell(
+            rowNumber: number,
+            column: OSFramework.Column.IColumn
+        ): void {
+            // This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
+            const currValue = this._grid.provider.getCellData(
+                rowNumber,
+                column.provider.index,
+                false
+            );
+            // Triggers the events of OnCellValueChange associated to a specific column in OS
+            this._triggerEventsFromColumn(
+                rowNumber,
+                column.provider.binding,
+                currValue,
+                currValue
+            );
+        }
+
         /**
          * Used to run the actions responsible for row validation per column.
          * Those actions might be included in the OnCellValueChange handler or in case the isMandatory column configuration is set.
@@ -465,25 +490,6 @@ namespace WijmoProvider.Feature {
                         currValue
                     );
                 });
-        }
-
-        public validateCell(
-            rowNumber: number,
-            column: OSFramework.Column.IColumn
-        ): void {
-            // This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
-            const currValue = this._grid.provider.getCellData(
-                rowNumber,
-                column.provider.index,
-                false
-            );
-            // Triggers the events of OnCellValueChange associated to a specific column in OS
-            this._triggerEventsFromColumn(
-                rowNumber,
-                column.provider.binding,
-                currValue,
-                currValue
-            );
         }
     }
 }

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -169,7 +169,7 @@ namespace WijmoProvider.Feature {
          * @param rowNumber Number of the row to trigger the events
          * @param isValid Wether or not row is valid
          */
-        private _setInvalidRows(rowNumber: number, isValid: boolean): void {
+        private _setRowStatus(rowNumber: number, isValid: boolean): void {
             const dataItem = this._grid.provider.rows[rowNumber].dataItem;
 
             if (this._invalidRows.indexOf(dataItem) === -1) {
@@ -400,11 +400,6 @@ namespace WijmoProvider.Feature {
             );
         }
 
-        public setRowStatus(rowNumber: number, isValid: boolean): void {
-            // set invalidRows with row number and flag that checks if status isValid and if there are invalid values on metadata
-            this._setInvalidRows(rowNumber, isValid);
-        }
-
         /**
          * Used to validate a cell by defining its metadata with a state that indicates if it is valid or not.
          * @param rowNumber Number of the row in which the action of validation should be triggered.
@@ -412,7 +407,7 @@ namespace WijmoProvider.Feature {
          * @param isValid Boolean that indicates whether the cell value meets a validation or data type rule. True, if the value conforms to the rule. False, otherwise.
          * @param errorMessage Message to be shown to the user when the value introduced is not valid.
          */
-        public setStatus(
+        public setCellStatus(
             rowNumber: number,
             columnWidgetID: string,
             isValid: boolean,
@@ -438,13 +433,18 @@ namespace WijmoProvider.Feature {
             );
 
             // set invalidRows with row number and flag that checks if status isValid and if there are invalid values on metadata
-            this._setInvalidRows(
+            this._setRowStatus(
                 rowNumber,
                 isValid && !this._isInvalidRowByRowNumber(rowNumber)
             );
 
             // Makes sure the grid gets refreshed after validation
             this._grid.provider.invalidate();
+        }
+
+        public setRowStatus(rowNumber: number, isValid: boolean): void {
+            // set invalidRows with row number and flag that checks if status isValid and if there are invalid values on metadata
+            this._setRowStatus(rowNumber, isValid);
         }
 
         public validateCell(


### PR DESCRIPTION
If we had one invalid line and removed it from the grid, the line would appear on InvalidLines and RemovedLines on GetChanges method. This PR addresses this issue, by setting all rows valid after they are removed.

### What was happening
* If we had one invalid line and removed it from the grid, the line would appear on InvalidLines and RemovedLines on GetChanges method. 

### What was done
* Created new method to set row status and turn rows valid after deletion

### Test Steps
1. Turn a row invalid and then remove it.
2. Call GetChanges API.
3. InvalidLines JSON should be empty




### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

