### PR TITLE
RGRIDT-994: Adding has thousand separator property

### DIFF
--- a/code/src/OSFramework/Configuration/Column/EditorConfigNumber.ts
+++ b/code/src/OSFramework/Configuration/Column/EditorConfigNumber.ts
@@ -4,6 +4,7 @@ namespace OSFramework.Configuration.Column {
      */
     export class EditorConfigNumber extends AbstractEditorConfig {
         public decimalPlaces: number;
+        public hasThousandSeparator: boolean;
         public maxValue?: number;
         public minValue?: number;
         public step: number;

--- a/code/src/WijmoProvider/Columns/NumberColumn.ts
+++ b/code/src/WijmoProvider/Columns/NumberColumn.ts
@@ -58,6 +58,15 @@ namespace WijmoProvider.Column {
             return wijmo.DataType.Number;
         }
 
+        private _setEditorFormat(hasThousandSeparator: boolean): void {
+            // if format starts with n, the number will have thousand separator
+            // if starts with f, it won't
+            const format = hasThousandSeparator ? 'n' : 'f';
+
+            this.config.format = `${format} ${this.editorConfig.decimalPlaces}`;
+            this.editorConfig.format = this.config.format;
+        }
+
         /**
          * Configure the column's editor to validate maximum values
          *
@@ -116,10 +125,7 @@ namespace WijmoProvider.Column {
 
             // if format starts with n, the number will have thousand separator
             // if starts with f, it won't
-            const format = this.editorConfig.hasThousandSeparator ? 'n' : 'f';
-
-            this.config.format = `${format} ${this.editorConfig.decimalPlaces}`;
-            this.editorConfig.format = this.config.format;
+            this._setEditorFormat(this.editorConfig.hasThousandSeparator);
         }
 
         public build(): void {
@@ -133,6 +139,10 @@ namespace WijmoProvider.Column {
             switch (propertyName) {
                 case 'decimalPlaces':
                     this._setFormat(propertyValue);
+                    this.applyConfigs();
+                    break;
+                case 'hasThousandSeparator':
+                    this._setEditorFormat(propertyValue);
                     this.applyConfigs();
                     break;
                 case 'minValue':

--- a/code/src/WijmoProvider/Columns/NumberColumn.ts
+++ b/code/src/WijmoProvider/Columns/NumberColumn.ts
@@ -122,9 +122,6 @@ namespace WijmoProvider.Column {
 
             this._setMaxValue();
             this._setMinValue();
-
-            // if format starts with n, the number will have thousand separator
-            // if starts with f, it won't
             this._setEditorFormat(this.editorConfig.hasThousandSeparator);
         }
 

--- a/code/src/WijmoProvider/Columns/NumberColumn.ts
+++ b/code/src/WijmoProvider/Columns/NumberColumn.ts
@@ -114,7 +114,11 @@ namespace WijmoProvider.Column {
             this._setMaxValue();
             this._setMinValue();
 
-            this.config.format = `n ${this.editorConfig.decimalPlaces}`;
+            // if format starts with n, the number will have thousand separator
+            // if starts with f, it won't
+            const format = this.editorConfig.hasThousandSeparator ? 'n' : 'f';
+
+            this.config.format = `${format} ${this.editorConfig.decimalPlaces}`;
             this.editorConfig.format = this.config.format;
         }
 


### PR DESCRIPTION
This PR adds hasThousandSeparator property to number columns

### What was happening
* It was not possible to have a column with year, because of the thousand separators. The year 2021 would become 2,021.

### What was done
* Added a property that indicates whether or not the number column should have a thousand separators.



### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

