### PR TITLE
RGRIDT-901: Adding GetCurrentPage and SetCurrengPage methods

### DIFF
--- a/code/src/GridAPI/Pagination.ts
+++ b/code/src/GridAPI/Pagination.ts
@@ -65,7 +65,7 @@ namespace GridAPI.Pagination {
      *
      * @export
      * @param {string} gridID Id of the Grid from which to obtain the pagination Index
-     * @return {*}  {number} Index of the current page, 0 based. Return -1 if the Grid is not yet initialized.
+     * @return {*}  {string} Stringified JSON structure containing Index of the current page, error message and code, and success boolean
      */
     export function GetCurrentPage(gridID: string): string {
         PerformanceAPI.SetMark('Pagination.GetCurrentPage');
@@ -168,7 +168,7 @@ namespace GridAPI.Pagination {
      * @export
      * @param {string} gridID
      * @param {number} n
-     * @returns {*}  {void}
+     * @returns {*}  {string} Stringified JSON structure containing error message and code, and success boolean
      */
     export function MoveToPage(gridID: string, n: number): string {
         PerformanceAPI.SetMark('Pagination.MoveToPage');

--- a/code/src/GridAPI/Pagination.ts
+++ b/code/src/GridAPI/Pagination.ts
@@ -67,13 +67,21 @@ namespace GridAPI.Pagination {
      * @param {string} gridID Id of the Grid from which to obtain the pagination Index
      * @return {*}  {number} Index of the current page, 0 based. Return -1 if the Grid is not yet initialized.
      */
-    export function GetCurrentPage(gridID: string): number {
+    export function GetCurrentPage(gridID: string): string {
         PerformanceAPI.SetMark('Pagination.GetCurrentPage');
+        let output = '';
 
-        if (!OSFramework.Helper.IsGridReady(gridID)) return -1;
+        if (!OSFramework.Helper.IsGridReady(gridID)) {
+            return JSON.stringify({
+                value: -1,
+                isSuccess: false,
+                message: 'Grid not found',
+                code: OSFramework.Enum.ErrorCodes.CFG_GridNotFound
+            });
+        }
+
         const grid = GridManager.GetGridById(gridID);
-
-        const pageIndex = grid.features.pagination.pageIndex;
+        output = JSON.stringify(grid.features.pagination.getCurrentPage());
 
         PerformanceAPI.SetMark('Pagination.GetCurrentPage-end');
         PerformanceAPI.GetMeasure(
@@ -82,7 +90,7 @@ namespace GridAPI.Pagination {
             'Pagination.GetCurrentPage-end'
         );
 
-        return pageIndex;
+        return output;
     }
 
     /**
@@ -162,13 +170,20 @@ namespace GridAPI.Pagination {
      * @param {number} n
      * @returns {*}  {void}
      */
-    export function MoveToPage(gridID: string, n: number): void {
+    export function MoveToPage(gridID: string, n: number): string {
         PerformanceAPI.SetMark('Pagination.MoveToPage');
+        let output = '';
 
-        if (!OSFramework.Helper.IsGridReady(gridID)) return;
+        if (!OSFramework.Helper.IsGridReady(gridID)) {
+            return JSON.stringify({
+                isSuccess: false,
+                message: 'Grid not found',
+                code: OSFramework.Enum.ErrorCodes.CFG_GridNotFound
+            });
+        }
+
         const grid = GridManager.GetGridById(gridID);
-
-        grid.features.pagination.moveToPage(n);
+        output = JSON.stringify(grid.features.pagination.moveToPage(n));
 
         PerformanceAPI.SetMark('Pagination.MoveToPage-end');
         PerformanceAPI.GetMeasure(
@@ -176,6 +191,8 @@ namespace GridAPI.Pagination {
             'Pagination.MoveToPage',
             'Pagination.MoveToPage-end'
         );
+
+        return output;
     }
 
     /**

--- a/code/src/GridAPI/Pagination.ts
+++ b/code/src/GridAPI/Pagination.ts
@@ -72,12 +72,15 @@ namespace GridAPI.Pagination {
         let output = '';
 
         if (!OSFramework.Helper.IsGridReady(gridID)) {
-            return JSON.stringify({
+            let returnMessage = new OSFramework.OSStructure.ReturnMessage();
+
+            returnMessage = {
                 value: -1,
                 isSuccess: false,
                 message: 'Grid not found',
                 code: OSFramework.Enum.ErrorCodes.CFG_GridNotFound
-            });
+            };
+            return JSON.stringify(returnMessage);
         }
 
         const grid = GridManager.GetGridById(gridID);
@@ -175,11 +178,15 @@ namespace GridAPI.Pagination {
         let output = '';
 
         if (!OSFramework.Helper.IsGridReady(gridID)) {
-            return JSON.stringify({
+            let returnMessage = new OSFramework.OSStructure.ReturnMessage();
+
+            returnMessage = {
+                value: -1,
                 isSuccess: false,
                 message: 'Grid not found',
                 code: OSFramework.Enum.ErrorCodes.CFG_GridNotFound
-            });
+            };
+            return JSON.stringify(returnMessage);
         }
 
         const grid = GridManager.GetGridById(gridID);

--- a/code/src/OSFramework/Enum/ErrorCodes.ts
+++ b/code/src/OSFramework/Enum/ErrorCodes.ts
@@ -9,6 +9,7 @@ namespace OSFramework.Enum {
 
         // Error Codes - API errors - Specific errors generated when exposing the component client actions API/Framework.
         API_FailedPaginationGetCurrentPage = 'GRID-API-01001',
+        API_FailedPaginationSetCurrentPage = 'GRID-API-01002',
         API_UnableToAddRow = 'GRID-API-02001',
         API_FailedAddRow = 'GRID-API-02002',
         API_UnableToRemoveRow = 'GRID-API-02001',

--- a/code/src/OSFramework/Enum/ErrorCodes.ts
+++ b/code/src/OSFramework/Enum/ErrorCodes.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Enum {
+    /**
+     * Codes that get the associated to specific returning messages indicated wheter the action had success or not.
+     */
+    export enum ErrorCodes {
+        // Error Codes - CONFiguration errors - Any error related with missing or wrong configuration of the application.
+        CFG_GridNotFound = 'GRID-CFG-01001',
+
+        // Error Codes - API errors - Specific errors generated when exposing the component client actions API/Framework.
+        API_FailedPaginationGetCurrentPage = 'GRID-API-01001',
+        API_UnableToAddRow = 'GRID-API-02001',
+        API_FailedAddRow = 'GRID-API-02002',
+        API_UnableToRemoveRow = 'GRID-API-02001',
+        API_FailedRemoveRow = 'GRID-API-02002'
+    }
+}

--- a/code/src/OSFramework/Feature/IPagination.ts
+++ b/code/src/OSFramework/Feature/IPagination.ts
@@ -10,11 +10,12 @@ namespace OSFramework.Feature {
         changePageSize(n: number): void;
         createPageButtons(phId: string, qtde: number): void;
         executeAction(action: Enum.PageAction): boolean;
+        getCurrentPage(): OSStructures.ReturnMessage;
         getValueByLabel(label: Enum.PageLabel): number;
         moveToFirstPage(): boolean;
         moveToLastPage(): boolean;
         moveToNextPage(): boolean;
-        moveToPage(n: number): boolean;
+        moveToPage(n: number): OSStructures.ReturnMessage;
         moveToPreviousPage(): boolean;
         registerLabel(label: Enum.PageLabel, phId: string): void;
     }

--- a/code/src/OSFramework/Feature/IPagination.ts
+++ b/code/src/OSFramework/Feature/IPagination.ts
@@ -10,12 +10,11 @@ namespace OSFramework.Feature {
         changePageSize(n: number): void;
         createPageButtons(phId: string, qtde: number): void;
         executeAction(action: Enum.PageAction): boolean;
-        getCurrentPage(): OSStructure.ReturnMessage;
         getValueByLabel(label: Enum.PageLabel): number;
         moveToFirstPage(): boolean;
         moveToLastPage(): boolean;
         moveToNextPage(): boolean;
-        moveToPage(n: number): OSStructure.ReturnMessage;
+        moveToPage(n: number): boolean;
         moveToPreviousPage(): boolean;
         registerLabel(label: Enum.PageLabel, phId: string): void;
     }

--- a/code/src/OSFramework/Feature/IPagination.ts
+++ b/code/src/OSFramework/Feature/IPagination.ts
@@ -10,12 +10,12 @@ namespace OSFramework.Feature {
         changePageSize(n: number): void;
         createPageButtons(phId: string, qtde: number): void;
         executeAction(action: Enum.PageAction): boolean;
-        getCurrentPage(): OSStructures.ReturnMessage;
+        getCurrentPage(): OSStructure.ReturnMessage;
         getValueByLabel(label: Enum.PageLabel): number;
         moveToFirstPage(): boolean;
         moveToLastPage(): boolean;
         moveToNextPage(): boolean;
-        moveToPage(n: number): OSStructures.ReturnMessage;
+        moveToPage(n: number): OSStructure.ReturnMessage;
         moveToPreviousPage(): boolean;
         registerLabel(label: Enum.PageLabel, phId: string): void;
     }

--- a/code/src/OSFramework/OSStructure/ReturnMessage.ts
+++ b/code/src/OSFramework/OSStructure/ReturnMessage.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-namespace OSFramework.OSStructures {
+namespace OSFramework.OSStructure {
     /** Return Message that is sent to Service Studio */
     export class ReturnMessage {
         /** Error Code from a list of codes */

--- a/code/src/OSFramework/OSStructure/ReturnMessage.ts
+++ b/code/src/OSFramework/OSStructure/ReturnMessage.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.OSStructures {
+    /** Return Message that is sent to Service Studio */
+    export class ReturnMessage {
+        /** Error Code from a list of codes */
+        public code?: Enum.ErrorCodes;
+        /** In case of success the message that gets returned is always {isSuccess: True} ignoring {code, message} */
+        public isSuccess?: boolean;
+        /** The message is always the reason why the operation failed. Usually used to define the message returned by the provider */
+        public message?: string;
+        /** The value returned from API */
+        public value?: any;
+    }
+}

--- a/code/src/WijmoProvider/Features/Pagination.ts
+++ b/code/src/WijmoProvider/Features/Pagination.ts
@@ -33,8 +33,6 @@ namespace WijmoProvider.Feature {
         private _pageSize: number;
         private _phId: string;
         private _qtdeButtons: number;
-        private _serverSideOnErrorMessage =
-            'It seems that you have server side pagination turned on. Switch it off and try again';
         private _view: wijmo.collections.CollectionView;
 
         constructor(grid: WijmoProvider.Grid.IGridWijmo, pageSize: number) {
@@ -194,30 +192,6 @@ namespace WijmoProvider.Feature {
             }
         }
 
-        public getCurrentPage(): OSFramework.OSStructure.ReturnMessage {
-            let isSuccess = true;
-            let value = this.pageIndex;
-            let message = '';
-            let code: OSFramework.Enum.ErrorCodes;
-
-            // we don't want to return page index if there is server side pagination
-            if (this._grid.config.serverSidePagination) {
-                isSuccess = false;
-                value = 0;
-                message = this._serverSideOnErrorMessage;
-                code =
-                    OSFramework.Enum.ErrorCodes
-                        .API_FailedPaginationGetCurrentPage;
-            }
-
-            return {
-                code,
-                isSuccess,
-                value,
-                message
-            };
-        }
-
         public getValueByLabel(label: OSFramework.Enum.PageLabel): number {
             switch (label) {
                 case OSFramework.Enum.PageLabel.PageCount:
@@ -249,25 +223,8 @@ namespace WijmoProvider.Feature {
             return this._view.moveToNextPage();
         }
 
-        public moveToPage(n: number): OSFramework.OSStructure.ReturnMessage {
-            let isSuccess = false;
-            let message = '';
-            let code: OSFramework.Enum.ErrorCodes;
-
-            // we don't want to set page index if there is server side pagination
-            if (this._grid.config.serverSidePagination) {
-                message = this._serverSideOnErrorMessage;
-                code =
-                    OSFramework.Enum.ErrorCodes
-                        .API_FailedPaginationSetCurrentPage;
-            }
-            isSuccess = this._view.moveToPage(n);
-
-            return {
-                code,
-                isSuccess,
-                message
-            };
+        public moveToPage(n: number): boolean {
+            return this._view.moveToPage(n);
         }
 
         public moveToPreviousPage(): boolean {

--- a/code/src/WijmoProvider/Features/Pagination.ts
+++ b/code/src/WijmoProvider/Features/Pagination.ts
@@ -200,6 +200,7 @@ namespace WijmoProvider.Feature {
             let message = '';
             let code: OSFramework.Enum.ErrorCodes;
 
+            // we don't want to return page index if there is server side pagination
             if (this._grid.config.serverSidePagination) {
                 isSuccess = false;
                 value = 0;
@@ -253,11 +254,12 @@ namespace WijmoProvider.Feature {
             let message = '';
             let code: OSFramework.Enum.ErrorCodes;
 
+            // we don't want to set page index if there is server side pagination
             if (this._grid.config.serverSidePagination) {
                 message = this._serverSideOnErrorMessage;
                 code =
                     OSFramework.Enum.ErrorCodes
-                        .API_FailedPaginationGetCurrentPage;
+                        .API_FailedPaginationSetCurrentPage;
             }
             isSuccess = this._view.moveToPage(n);
 

--- a/code/src/WijmoProvider/Features/Pagination.ts
+++ b/code/src/WijmoProvider/Features/Pagination.ts
@@ -194,7 +194,7 @@ namespace WijmoProvider.Feature {
             }
         }
 
-        public getCurrentPage(): OSFramework.OSStructures.ReturnMessage {
+        public getCurrentPage(): OSFramework.OSStructure.ReturnMessage {
             let isSuccess = true;
             let value = this.pageIndex;
             let message = '';
@@ -249,7 +249,7 @@ namespace WijmoProvider.Feature {
             return this._view.moveToNextPage();
         }
 
-        public moveToPage(n: number): OSFramework.OSStructures.ReturnMessage {
+        public moveToPage(n: number): OSFramework.OSStructure.ReturnMessage {
             let isSuccess = false;
             let message = '';
             let code: OSFramework.Enum.ErrorCodes;

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -174,7 +174,7 @@ namespace WijmoProvider.Feature {
          * Add a new row to the grid with all cells empty.
          * @returns ReturnMessage containing the resulting code from the adding rows and the error message in case of failure.
          */
-        public addNewRows(): OSFramework.OSStructures.ReturnMessage {
+        public addNewRows(): OSFramework.OSStructure.ReturnMessage {
             if (!this._canAddRows()) {
                 // Return error
                 return {
@@ -320,7 +320,7 @@ namespace WijmoProvider.Feature {
          * Remove all selected rows from the grid.
          * @returns ReturnMessage containing the resulting code from the removing rows and the error message in case of failure.
          */
-        public removeSelectedRows(): OSFramework.OSStructures.ReturnMessage {
+        public removeSelectedRows(): OSFramework.OSStructure.ReturnMessage {
             if (!this._canRemoveRows()) {
                 return {
                     code: OSFramework.Enum.ErrorCodes.API_UnableToRemoveRow,

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -1,7 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace WijmoProvider.Feature {
-    type _ErrorMessage = { code: OSFramework.Enum.ErrorCodes; message: string };
-
     class CssClassInfo {
         /**
          * Contains all CSS classes from a specific row.

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -174,7 +174,7 @@ namespace WijmoProvider.Feature {
 
         /**
          * Add a new row to the grid with all cells empty.
-         * @returns ErrorMessage containing the resulting code from the adding rows and the error message in case of failure.
+         * @returns ReturnMessage containing the resulting code from the adding rows and the error message in case of failure.
          */
         public addNewRows(): OSFramework.OSStructures.ReturnMessage {
             if (!this._canAddRows()) {
@@ -320,7 +320,7 @@ namespace WijmoProvider.Feature {
 
         /**
          * Remove all selected rows from the grid.
-         * @returns ErrorMessage containing the resulting code from the removing rows and the error message in case of failure.
+         * @returns ReturnMessage containing the resulting code from the removing rows and the error message in case of failure.
          */
         public removeSelectedRows(): OSFramework.OSStructures.ReturnMessage {
             if (!this._canRemoveRows()) {

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace WijmoProvider.Feature {
-    type _ErrorMessage = { code: number; message: string };
+    type _ErrorMessage = { code: OSFramework.Enum.ErrorCodes; message: string };
 
     class CssClassInfo {
         /**
@@ -176,13 +176,14 @@ namespace WijmoProvider.Feature {
          * Add a new row to the grid with all cells empty.
          * @returns ErrorMessage containing the resulting code from the adding rows and the error message in case of failure.
          */
-        public addNewRows(): _ErrorMessage {
+        public addNewRows(): OSFramework.OSStructures.ReturnMessage {
             if (!this._canAddRows()) {
                 // Return error
                 return {
-                    code: 201,
+                    code: OSFramework.Enum.ErrorCodes.API_UnableToAddRow,
                     message:
-                        'It seems that you have an active filter, group or sort on your columns. Remove them and try again.'
+                        'It seems that you have an active filter, group or sort on your columns. Remove them and try again.',
+                    isSuccess: false
                 };
             }
 
@@ -230,9 +231,13 @@ namespace WijmoProvider.Feature {
             // Make sure the count of rows is correct after adding rows.
             if (this._getRowsCount() === expectedRowCount) {
                 // Return success
-                return { code: 200, message: 'Success' };
+                return { message: 'Success', isSuccess: true };
             } else {
-                return { code: 400, message: 'Error' };
+                return {
+                    code: OSFramework.Enum.ErrorCodes.API_FailedAddRow,
+                    message: 'Error',
+                    isSuccess: false
+                };
             }
         }
 
@@ -317,12 +322,13 @@ namespace WijmoProvider.Feature {
          * Remove all selected rows from the grid.
          * @returns ErrorMessage containing the resulting code from the removing rows and the error message in case of failure.
          */
-        public removeSelectedRows(): _ErrorMessage {
+        public removeSelectedRows(): OSFramework.OSStructures.ReturnMessage {
             if (!this._canRemoveRows()) {
                 return {
-                    code: 400,
+                    code: OSFramework.Enum.ErrorCodes.API_UnableToRemoveRow,
                     message:
-                        'It seems that you have an active filter, group or sort on your columns. Remove them and try again.'
+                        'It seems that you have an active filter, group or sort on your columns. Remove them and try again.',
+                    isSuccess: false
                 };
             }
             //This will avoid the same row being selected multiple times
@@ -370,9 +376,13 @@ namespace WijmoProvider.Feature {
 
             // Make sure the count of rows is correct after removing rows.
             if (this._getRowsCount() === expectedRowCount) {
-                return { code: 200, message: 'Success' };
+                return { message: 'Success', isSuccess: true };
             } else {
-                return { code: 400, message: 'Error' };
+                return {
+                    code: OSFramework.Enum.ErrorCodes.API_FailedRemoveRow,
+                    message: 'Error',
+                    isSuccess: false
+                };
             }
         }
     }


### PR DESCRIPTION
This PR adds GetCurrentPage and SetCurrentPage client actions onto our module.

### What was done
* Adjusted GetCurrentPage API method so it returns error messages, whether or not the operation was successful, and the current page index as well.
* Created SetCurrentPage API method, that returns error messages and whether or not the operation was successful.
* Created ReturnMessage Structure and error code enumerator.
* Adjusted AddRows and RemoveRows so they use the previously mentioned structure and enum.

### Test Steps
1. Go to sample
2. Change pages and press the GetCurrentPage button
3. It should show the current page index on the input

1. Go to sample
2. Press the SetCurrentPage button
3. It should change to the 4th page.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

