### PR TITLE
RGRIDT-994: Fixing has thousand separator change property

### DIFF
--- a/code/src/WijmoProvider/Columns/NumberColumn.ts
+++ b/code/src/WijmoProvider/Columns/NumberColumn.ts
@@ -139,6 +139,7 @@ namespace WijmoProvider.Column {
                     this.applyConfigs();
                     break;
                 case 'hasThousandSeparator':
+                    this.editorConfig.hasThousandSeparator = propertyValue;
                     this._setEditorFormat(propertyValue);
                     this.applyConfigs();
                     break;


### PR DESCRIPTION
There was a bug when changing properties for the number column, as the hasThousandSeparator wasn't being assigned.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

