### PR TITLE
RGRIDT-1010: New rows won't have key binding if it wasn't set

### DIFF
--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -131,7 +131,10 @@ namespace OSFramework.Grid {
 
         // set primary key field of dataItem
         private _setKeyBinding(data): any {
-            _.set(data, this.parentGrid.config.keyBinding, this._counter--);
+            // we only want to do this if we have key binding set
+            if (this.parentGrid.config.keyBinding) {
+                _.set(data, this.parentGrid.config.keyBinding, this._counter--);
+            }
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
This PR fixes a bug on addNewRows

### What was happening
* We were setting keyBinding attribute into data item even if the grid didn't have a key binding defined by the user. 

### What was done
* Added a check if there is key binding.

### Test Steps
Automated test Get Changed Lines


### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

