### PR TITLE
RGRIDT-1011: Fixing applied symbol being lost after changing decimal places

### DIFF
--- a/code/src/WijmoProvider/Columns/CurrencyColumn.ts
+++ b/code/src/WijmoProvider/Columns/CurrencyColumn.ts
@@ -14,13 +14,11 @@ namespace WijmoProvider.Column {
                 new OSFramework.Event.Column.ColumnEventsManager(this);
         }
 
-        protected _setFormat(decimalPlaces: number, symbol?: string): void {
+        protected _setFormat(decimalPlaces: number): void {
             //The supper will calculate the Min and Max and validate decimalPlaces
             super._setFormat(decimalPlaces);
 
-            this.config.format = `c${this.editorConfig.decimalPlaces} ${
-                symbol || this.editorConfig.symbol
-            }`;
+            this.config.format = `c${this.editorConfig.decimalPlaces} ${this.editorConfig.symbol}`;
             this.editorConfig.format = this.config.format;
         }
 
@@ -37,10 +35,8 @@ namespace WijmoProvider.Column {
         public changeProperty(propertyName: string, propertyValue: any): void {
             switch (propertyName) {
                 case 'symbol':
-                    this._setFormat(
-                        this.editorConfig.decimalPlaces,
-                        propertyValue
-                    );
+                    this.editorConfig.symbol = propertyValue;
+                    this._setFormat(this.editorConfig.decimalPlaces);
                     this.applyConfigs();
                     break;
                 default:


### PR DESCRIPTION
This PR fixes applied symbol being lost after changing decimal places


### What was happening
* ![symbolBug](https://user-images.githubusercontent.com/3113318/134867241-3326ba4a-dace-4aaa-87d7-65106eeabee1.gif)


### What was done
* When symbol is changed, we update editorConfigs.



### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

