### PR TITLE
RGRIDT-1012: Fixing language

### DIFF
--- a/code/src/WijmoProvider/Helper/Translation.ts
+++ b/code/src/WijmoProvider/Helper/Translation.ts
@@ -22,6 +22,10 @@ namespace WijmoProvider.Helper.Translation {
     }
 
     export function SetLanguage(language: string, url: string): void {
+        // on wijmo version 5.20212.808 and prior, when importing english culture files, the grid has some different resources
+        // than if we used default translation. in order to prevent this, we don't want to import english culture files.
+        if (language === 'en-US' || language.includes('en')) return;
+
         const regex = new RegExp('culture.(.*)(?=.min)');
         const transposedLanguage = transposeLanguageFormat(language);
 


### PR DESCRIPTION
This PR fixes a bug on wijmo's side that messes up the grid's language resources.

### What was happening
* Grid behaves in a different way when English culture file is imported

### What was done
* If English language culture is imported, we ignore it.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

