### PR TITLE
RGRIDT-994: Grid configs had lost thousand separator

### DIFF
--- a/code/src/WijmoProvider/Columns/NumberColumn.ts
+++ b/code/src/WijmoProvider/Columns/NumberColumn.ts
@@ -58,7 +58,8 @@ namespace WijmoProvider.Column {
             return wijmo.DataType.Number;
         }
 
-        private _setEditorFormat(hasThousandSeparator: boolean): void {
+        // by default, we want numbers to have thousand separator
+        private _setEditorFormat(hasThousandSeparator = true): void {
             // if format starts with n, the number will have thousand separator
             // if starts with f, it won't
             const format = hasThousandSeparator ? 'n' : 'f';


### PR DESCRIPTION
### What was happening
* On number/currency columns, grid configs had lost thousand separators.

### What was done
* Added default value for hasThousandSeparator

### Test Steps
1. Open grid configs
2. It should have thousand separator on number/currency columns


### Checklist
* [x] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

