### PR TITLE
Fixing asynchronously behavior with pagination

### DIFF
--- a/code/src/WijmoProvider/Features/Pagination.ts
+++ b/code/src/WijmoProvider/Features/Pagination.ts
@@ -41,6 +41,18 @@ namespace WijmoProvider.Feature {
             this._pageSize = pageSize;
         }
 
+        private _setValueInPh(
+            label: OSFramework.Enum.PageLabel,
+            phId: string
+        ): void {
+            const element = document.getElementById(phId);
+            const value = this.getValueByLabel(label);
+
+            if (element && value) {
+                element.textContent = value.toString();
+            }
+        }
+
         private _update(): void {
             if (this._phId) {
                 this.createPageButtons(this._phId, this._qtdeButtons);
@@ -235,12 +247,9 @@ namespace WijmoProvider.Feature {
             label: OSFramework.Enum.PageLabel,
             phId: string
         ): void {
+            this._setValueInPh(label, phId);
             this._view.collectionChanged.addHandler(() => {
-                const element = document.getElementById(phId);
-
-                if (element)
-                    element.textContent =
-                        this.getValueByLabel(label).toString();
+                this._setValueInPh(label, phId);
             });
         }
     }

--- a/code/src/WijmoProvider/Features/Pagination.ts
+++ b/code/src/WijmoProvider/Features/Pagination.ts
@@ -40,7 +40,15 @@ namespace WijmoProvider.Feature {
             this._view = grid.provider.itemsSource;
             this._pageSize = pageSize;
         }
-
+        /**
+         * This method is used to setup the value of the pagination
+         * in the placeholder.
+         *
+         * @private
+         * @param {OSFramework.Enum.PageLabel} label
+         * @param {string} phId
+         * @memberof Pagination
+         */
         private _setValueInPh(
             label: OSFramework.Enum.PageLabel,
             phId: string
@@ -48,7 +56,10 @@ namespace WijmoProvider.Feature {
             const element = document.getElementById(phId);
             const value = this.getValueByLabel(label);
 
+            //If we found the placeholder (!== null) and the
+            //provider already has a value (!== NaN).
             if (element && value) {
+                //Let's set the value in the placeholder
                 element.textContent = value.toString();
             }
         }
@@ -205,22 +216,23 @@ namespace WijmoProvider.Feature {
         }
 
         public getValueByLabel(label: OSFramework.Enum.PageLabel): number {
-            switch (label) {
-                case OSFramework.Enum.PageLabel.PageCount:
-                    return this.pageCount;
-                case OSFramework.Enum.PageLabel.PageIndex:
-                    return this.pageIndex + 1;
-                case OSFramework.Enum.PageLabel.PageSize:
-                    return this.pageSize;
-                case OSFramework.Enum.PageLabel.RowEnd:
-                    return this.rowEnd;
-                case OSFramework.Enum.PageLabel.RowStart:
-                    return this.rowStart;
-                case OSFramework.Enum.PageLabel.RowTotal:
-                    return this.rowTotal;
-                default:
-                    break;
+            if (this._view) {
+                switch (label) {
+                    case OSFramework.Enum.PageLabel.PageCount:
+                        return this.pageCount;
+                    case OSFramework.Enum.PageLabel.PageIndex:
+                        return this.pageIndex + 1;
+                    case OSFramework.Enum.PageLabel.PageSize:
+                        return this.pageSize;
+                    case OSFramework.Enum.PageLabel.RowEnd:
+                        return this.rowEnd;
+                    case OSFramework.Enum.PageLabel.RowStart:
+                        return this.rowStart;
+                    case OSFramework.Enum.PageLabel.RowTotal:
+                        return this.rowTotal;
+                }
             }
+            return NaN;
         }
 
         public moveToFirstPage(): boolean {
@@ -243,11 +255,26 @@ namespace WijmoProvider.Feature {
             return this._view.moveToPreviousPage();
         }
 
+        /**
+         * This method is responsible for registering the
+         * placeholder in which we'll want to add the number
+         * corresponding to the pagination.
+         *
+         * @param {OSFramework.Enum.PageLabel} label
+         * @param {string} phId
+         * @memberof Pagination
+         */
         public registerLabel(
             label: OSFramework.Enum.PageLabel,
             phId: string
         ): void {
+            //Since the register can happen at any moment in time,
+            //we'll first try to immediatly set, if both provider
+            //and placeholder are ready for such.
             this._setValueInPh(label, phId);
+            //In a later stage we want this to be done when there's
+            //an event of the provider saying that the collection
+            //(visible rows) has changed.
             this._view.collectionChanged.addHandler(() => {
                 this._setValueInPh(label, phId);
             });


### PR DESCRIPTION
This PR is for fixing the asynchronous behavior in the pagination case.

### What was happening
* Since invoking the handlers of the events became asynchronous the moment in which we append to the events of the provider,  became different. This caused the handlers to lose the first event of the provider. leaving the pagination placeholders empty.
![grid-pagination](https://user-images.githubusercontent.com/10534623/135094741-92f74507-8f1d-47e0-b3ce-a37758e1c265.gif)

### What was done
* Just like when someone is trying to listen to the OnInitialize of the grid and the event has already happen, we now do the same, and trigger the handler upon adding it, if both the placeholder and the provider already has a value.
![grid-pagination-2](https://user-images.githubusercontent.com/10534623/135095089-458c48fe-0df2-404b-8ac0-e560ecead7b4.gif)

### Test Steps
1. Enter in a page using the grid with pagination
2. Check if the fields are filled up:
![image](https://user-images.githubusercontent.com/10534623/135093341-4e388e47-4eb7-4e88-973a-f8cf9c72eb3b.png)

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

