### PR TITLE
RGRIDT-1037: Adjusting grid behavior when it has checkbox

### DIFF
--- a/code/src/WijmoProvider/Features/RowHeader.ts
+++ b/code/src/WijmoProvider/Features/RowHeader.ts
@@ -48,25 +48,31 @@ namespace WijmoProvider.Feature {
         private _buildRowHeader() {
             if (this.hasCheckbox) {
                 this._buildCheckbox();
+                // with checkbox, we want to prevent row selection on row number and
+                // want to still be able to select cells.
                 this._disableRowSelectionOnRowNumber();
-
                 this._grid.provider.selectionMode =
                     wijmo.grid.SelectionMode.CellRange;
 
-                // check if Grid has checked rows
-                this._grid.provider.formatItem.addHandler((s) => {
-                    const element =
-                        s.columnHeaders.hostElement.querySelector(
-                            '.wj-cell.wj-header'
+                // if grid has checked rows, add custom class so column headers are selected as well
+                this._grid.provider.formatItem.addHandler((s, e) => {
+                    if (e.panel.cellType === wijmo.grid.CellType.RowHeader) {
+                        const element =
+                            s.columnHeaders.hostElement.querySelector(
+                                '.wj-cell.wj-header'
+                            );
+
+                        const el = s.rowHeaders.hostElement.querySelector(
+                            "input[type='checkbox']:checked"
                         );
 
-                    const el = s.hostElement.querySelector(
-                        ".wj-header input[type='checkbox']:checked"
-                    );
-                    if (el) {
-                        wijmo.addClass(element, 'checked-columns');
-                    } else if (wijmo.hasClass(element, 'checked-columns')) {
-                        wijmo.removeClass(element, 'checked-columns');
+                        if (el) {
+                            wijmo.addClass(element, 'checked-column-header');
+                        } else if (
+                            wijmo.hasClass(element, 'checked-column-header')
+                        ) {
+                            wijmo.removeClass(element, 'checked-column-header');
+                        }
                     }
                 });
             }

--- a/code/src/WijmoProvider/Features/RowHeader.ts
+++ b/code/src/WijmoProvider/Features/RowHeader.ts
@@ -12,6 +12,7 @@ namespace WijmoProvider.Feature {
             this._grid = grid;
             this._rowHeaderType = rowHeaderType;
         }
+
         public get type(): OSFramework.Enum.RowHeader {
             return this._rowHeaderType;
         }
@@ -39,18 +40,48 @@ namespace WijmoProvider.Feature {
             column.allowSorting = false;
             column.allowDragging = false;
             column.allowMerging = false;
-            this._grid.provider.rowHeaders.columns.push(column);
 
-            new wijmo.grid.selector.Selector(column);
+            new wijmo.grid.selector.Selector(this._grid.provider);
+            this._grid.provider.rowHeaders.columns.insert(0, column);
         }
 
         private _buildRowHeader() {
             if (this.hasCheckbox) {
                 this._buildCheckbox();
+                this._disableRowSelectionOnRowNumber();
+
+                this._grid.provider.selectionMode =
+                    wijmo.grid.SelectionMode.CellRange;
+
+                // check if Grid has checked rows
+                this._grid.provider.formatItem.addHandler((s) => {
+                    const element =
+                        s.columnHeaders.hostElement.querySelector(
+                            '.wj-cell.wj-header'
+                        );
+
+                    const el = s.hostElement.querySelector(
+                        ".wj-header input[type='checkbox']:checked"
+                    );
+                    if (el) {
+                        wijmo.addClass(element, 'checked-columns');
+                    } else if (wijmo.hasClass(element, 'checked-columns')) {
+                        wijmo.removeClass(element, 'checked-columns');
+                    }
+                });
             }
             if (!this.hasRowNumber) {
                 this._grid.features.autoRowNumber.setState(false);
             }
+        }
+
+        /**
+         * Disable row number header from being clicked as we want to select rows only with checkbox
+         */
+        private _disableRowSelectionOnRowNumber(): void {
+            this._grid.provider.hostElement
+                .querySelector('.wj-rowheaders')
+                .addEventListener('mousedown', (e) => e.preventDefault());
         }
 
         public build(): void {

--- a/code/src/WijmoProvider/Features/RowHeader.ts
+++ b/code/src/WijmoProvider/Features/RowHeader.ts
@@ -57,21 +57,31 @@ namespace WijmoProvider.Feature {
                 // if grid has checked rows, add custom class so column headers are selected as well
                 this._grid.provider.formatItem.addHandler((s, e) => {
                     if (e.panel.cellType === wijmo.grid.CellType.RowHeader) {
-                        const element =
+                        const columnHeaderElement =
                             s.columnHeaders.hostElement.querySelector(
                                 '.wj-cell.wj-header'
                             );
 
-                        const el = s.rowHeaders.hostElement.querySelector(
-                            "input[type='checkbox']:checked"
-                        );
+                        const rowHeaderCheckedElement =
+                            s.rowHeaders.hostElement.querySelector(
+                                "input[type='checkbox']:checked"
+                            );
 
-                        if (el) {
-                            wijmo.addClass(element, 'checked-column-header');
+                        if (rowHeaderCheckedElement) {
+                            wijmo.addClass(
+                                columnHeaderElement,
+                                'checked-column-header'
+                            );
                         } else if (
-                            wijmo.hasClass(element, 'checked-column-header')
+                            wijmo.hasClass(
+                                columnHeaderElement,
+                                'checked-column-header'
+                            )
                         ) {
-                            wijmo.removeClass(element, 'checked-column-header');
+                            wijmo.removeClass(
+                                columnHeaderElement,
+                                'checked-column-header'
+                            );
                         }
                     }
                 });

--- a/code/styles/Grid.css
+++ b/code/styles/Grid.css
@@ -243,8 +243,8 @@
         );
 }
 
-.wj-cell.wj-header.checked-columns,
-.wj-cell.wj-header.checked-columns ~ .wj-header {
+.wj-cell.wj-header.checked-column-header,
+.wj-cell.wj-header.checked-column-header ~ .wj-header {
     background: linear-gradient(
             var(--color-primary-selected),
             var(--color-primary-selected)

--- a/code/styles/Grid.css
+++ b/code/styles/Grid.css
@@ -166,6 +166,16 @@
 .wj-flexgrid .wj-cell.wj-hasdropdown .wj-dropdown.wj-inputdate input {
     width: 100%;
 }
+
+.wj-flexgrid .wj-cell label:before {
+    content: '';
+    bottom: 0;
+    right: 0;
+    top: 0;
+    left: 0;
+    position: absolute;
+}
+
 .wj-colheaders > .wj-row > .wj-cell::before,
 .wj-flexgrid .wj-colheaders .wj-header.wj-colgroup.wj-cell::before {
     content: '';
@@ -223,6 +233,18 @@
 }
 
 .wj-cell.wj-header.wj-state-multi-selected {
+    background: linear-gradient(
+            var(--color-primary-selected),
+            var(--color-primary-selected)
+        ),
+        linear-gradient(
+            var(--datagrid-header-cell-background),
+            var(--datagrid-header-cell-background)
+        );
+}
+
+.wj-cell.wj-header.checked-columns,
+.wj-cell.wj-header.checked-columns ~ .wj-header {
     background: linear-gradient(
             var(--color-primary-selected),
             var(--color-primary-selected)
@@ -1066,18 +1088,18 @@
     -servicestudio-font-weight: bold;
 }
 
-.server-side-message{
-    -servicestudio-background: #DCECFD;
-    -servicestudio-color: #938E8E;
+.server-side-message {
+    -servicestudio-background: #dcecfd;
+    -servicestudio-color: #938e8e;
     -servicestudio-font-family: 'Verdana';
     -servicestudio-font-size: 12px;
     -servicestudio-padding: 15px 15px;
 }
 
 .server-side-message:before {
-    -servicestudio-content: '🛈 To use server-side pagination, follow the steps detailed in: '
+    -servicestudio-content: '🛈 To use server-side pagination, follow the steps detailed in: ';
 }
 
 .server-side-message > .server-side-pagination-link {
-    -servicestudio-color: #006DE9;
+    -servicestudio-color: #006de9;
 }


### PR DESCRIPTION
### What was done
* When the grid has checkbox, we disable clicking on row header number
* Adjusted checkbox CSS.
* Added ability to fat-finger checkbox.
* When a row is checked, all column headers are now selected. 

### Test Steps
1. Try to click the first-row header.
2. It should not do anything.

1. Check any row.
2. Row should be painted.
3. Column headers should be painted as well.

1. "Fat-finger" a checkbox.
2. Row should be checked.

1. Cell selection should still be possible.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

