### PR TITLE
RGRIDT-1051: Fixing issue when adding rows and removing wrong use of API

### DIFF
--- a/code/src/WijmoProvider/Features/ColumnFilter.ts
+++ b/code/src/WijmoProvider/Features/ColumnFilter.ts
@@ -62,9 +62,11 @@ namespace WijmoProvider.Feature {
         }
 
         public get isGridFiltered(): boolean {
+            // when filter is active, the filterDefinition object usually has filterType different than 0
+            // and it has a type. we should check for both.
             return (
                 JSON.parse(this._filter.filterDefinition).filters.filter(
-                    (x) => x.filterType !== 0
+                    (x) => x.filterType !== 0 && !!x.type
                 ).length > 0
             );
         }
@@ -168,7 +170,7 @@ namespace WijmoProvider.Feature {
             columnID: string,
             filterType: wijmo.grid.filter.FilterType
         ): void {
-            const column = GridAPI.ColumnManager.GetColumnById(columnID);
+            const column = this._grid.getColumn(columnID);
 
             if (column) {
                 this._filter.getColumnFilter(column.provider).filterType =
@@ -177,7 +179,7 @@ namespace WijmoProvider.Feature {
         }
 
         public clear(columnID: string): void {
-            const column = GridAPI.ColumnManager.GetColumnById(columnID);
+            const column = this._grid.getColumn(columnID);
 
             this._filter.getColumnFilter(column.provider).clear();
             this._grid.provider.collectionView.refresh();

--- a/code/src/WijmoProvider/Features/ColumnFilter.ts
+++ b/code/src/WijmoProvider/Features/ColumnFilter.ts
@@ -66,7 +66,9 @@ namespace WijmoProvider.Feature {
             // and it has a type. we should check for both.
             return (
                 JSON.parse(this._filter.filterDefinition).filters.filter(
-                    (x) => x.filterType !== 0 && !!x.type
+                    (filterDefinition) =>
+                        filterDefinition.filterType !== 0 &&
+                        !!filterDefinition.type
                 ).length > 0
             );
         }


### PR DESCRIPTION
This PR is for a bug fix reported on the [forum](https://www.outsystems.com/forums/discussion/74212/adding-row-when-using-dependant-dropdowns-gives-error/) by [Bård Indredavik](https://www.outsystems.com/profile/p6p2u4tgiv/).

### What was happening
* Whenever we tried to add rows on the grid with dependent dropdowns, an error was thrown. This was happening because the grid behaved as if the filters were applied.

### What was done
* Added an extra validation on the filter test.
* Removed wrong use of GridAPI on wijmoProvider.

### Test Steps
1. Open the context menu and add row.
2. Row should be added.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
