### PR TITLE
Adding the code to handle "ar-SA" language

### DIFF
--- a/code/src/@types/wijmo-5.20212.808-rc/cultures/wijmo.culture.ar-SA.d.ts
+++ b/code/src/@types/wijmo-5.20212.808-rc/cultures/wijmo.culture.ar-SA.d.ts
@@ -1,0 +1,1 @@
+declare namespace wijmo {}

--- a/code/src/WijmoProvider/Helper/Translation.ts
+++ b/code/src/WijmoProvider/Helper/Translation.ts
@@ -6,6 +6,7 @@ namespace WijmoProvider.Helper.Translation {
         switch (language) {
             //the following languages exist in these variants
             case 'ar-AE':
+            case 'ar-SA':
             case 'de-CH':
             case 'en-CA':
             case 'de-GB':


### PR DESCRIPTION
This PR is adding the code to support ar-SA language. It is related with the issue raised in this [thread in OutSystems forum](https://www.outsystems.com/forums/discussion/72980/reactive-data-grid-arabic-support/). Special kudos to [Ahmad Abd-Allah](https://www.outsystems.com/profile/dcz3t7fakl/) for fixing the translations to "ar-AE" and providing the "ar-SA" translations. 

### What was happening
* Although the language file, was already available in the module, the code, was still not loading the correct translation, for missing the case for it.

### What was done
* Added the case for the "ar-SA" language

### Test Steps
1. Go to the test page
2. Change to the locale to ar-SA
3. See the grid text getting correctly translated.


### Checklist
* [x] tested locally
* [ ] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

