### PR TITLE
RGRIDT-1039: Add/remove rows according to selection/checkbox

### DIFF
--- a/code/src/WijmoProvider/Features/RowHeader.ts
+++ b/code/src/WijmoProvider/Features/RowHeader.ts
@@ -52,7 +52,7 @@ namespace WijmoProvider.Feature {
                 // want to still be able to select cells.
                 this._disableRowSelectionOnRowNumber();
                 this._grid.provider.selectionMode =
-                    wijmo.grid.SelectionMode.CellRange;
+                    wijmo.grid.SelectionMode.MultiRange;
 
                 // if grid has checked rows, add custom class so column headers are selected as well
                 this._grid.provider.formatItem.addHandler((s, e) => {

--- a/code/src/WijmoProvider/Features/Selection.ts
+++ b/code/src/WijmoProvider/Features/Selection.ts
@@ -318,15 +318,30 @@ namespace WijmoProvider.Feature {
                 ...this._grid.provider.selectedRanges.filter((p) => p.isValid)
             );
             // }
-            return this._getCheckedRows()
+
+            // create checkedRows cell range.
+            let checkedRowsRange = this._getCheckedRows()
                 .map((p) => new wijmo.grid.CellRange(p, 0, p, maxCol))
                 .filter((p) => {
                     for (let i = 0; i < ranges.length; i++) {
                         if (ranges[i].contains(p)) return false;
                     }
                     return true;
-                })
-                .concat(ranges);
+                });
+
+            // for each cellRange, check if it has any row intersection with checked rows
+            // if it has, we add it to checkedRows array.
+            ranges.forEach((range) => {
+                if (
+                    !checkedRowsRange.some((checked) =>
+                        checked.intersectsRow(range)
+                    )
+                ) {
+                    checkedRowsRange = [...checkedRowsRange, range];
+                }
+            });
+
+            return checkedRowsRange;
         }
 
         public getSelectedRows(): number[] {


### PR DESCRIPTION
This PR adjusts the necessary methods to ensure row addition/removal respects cell selection and row checkbox selection.

### **Since this change might cause side effects, please wait until the full suite of tests has run.**

### What was happening
* With the newly added feature of checkbox, whenever we had a row checked and a cell on the same row selected, the grid considered there were two selections, and it would add/remove two rows.

### What was done
* Adjusted getProviderAllSelections method to remove intersection between checkedRows and cellSelection from same rows.
* On a previous task, the grid's selection mode was set to CellRange when we had Checkbox. This mode didn't allow us to select multiple cells with CTRL. Switched back to MultiRange. 

### Test Steps
1. Check a row.
2. Select a cell on the same row.
3. Open the context menu and add a row.

Expected result: Only one row should've been added.

1. Check a row.
2. Select a cell from another row.
3. Open the context menu and add a row.

Expected result: Two rows should've been added.

1. Check a row.
2. Change pages and check another row
3. Open the context menu and add a row.

Expected result: Only one row should've been added.

Note: If a row is checked and a cell is selected, the grid will always consider two selections and will add two rows.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint

