### PR TITLE
RGRIDT-1037: Adding align center to rowheader column

### DIFF
--- a/code/src/WijmoProvider/Features/RowHeader.ts
+++ b/code/src/WijmoProvider/Features/RowHeader.ts
@@ -40,6 +40,7 @@ namespace WijmoProvider.Feature {
             column.allowSorting = false;
             column.allowDragging = false;
             column.allowMerging = false;
+            column.align = 'center';
 
             new wijmo.grid.selector.Selector(this._grid.provider);
             this._grid.provider.rowHeaders.columns.insert(0, column);


### PR DESCRIPTION
### What was happening
* The first-row header column was not centered.

### What was done
* Adjusted column alignment.

### Test Steps
1. Grid should have both row headers aligned in the center.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint

