### PR TITLE
RGRIDT-1056: Adjusting conditional format to work with null dates

### DIFF
--- a/code/src/WijmoProvider/Features/ConditionalFormat.ts
+++ b/code/src/WijmoProvider/Features/ConditionalFormat.ts
@@ -13,6 +13,24 @@ namespace WijmoProvider.Feature {
     function Evaluate(operator: Rules, comparedValue: any, cellValue: any) {
         // in case we are comparing dates
         if (typeof cellValue.getMonth === 'function') {
+            // Whenever we have null dates coming from OS, it has a different timezone than today's
+            // this is the way JS handles dates before 1911: "historical timezone offsets are applied, prior to about 1900 most were not even hour or half hour offsets."
+            // so we must ensure that our compared value (OS Null date) has this GMT as well.
+            const comparedDate = new Date(comparedValue);
+            const comparedYear = comparedDate.getUTCFullYear();
+            if (comparedYear <= 1911) {
+                const timezoneOffset = cellValue.toISOString().split('T')[1];
+
+                // get UTC date of compared value and add timezoneOffset to it
+                comparedValue =
+                    `${comparedYear}-0${(comparedDate.getUTCMonth() + 1)
+                        .toString()
+                        .slice(-2)}-0${comparedDate
+                        .getUTCDate()
+                        .toString()
+                        .slice(-2)}T` + timezoneOffset;
+            }
+
             cellValue = Helper.DataUtils.GetTicksFromDate(
                 cellValue,
                 comparedValue.indexOf('Z') > -1


### PR DESCRIPTION
This PR adjusts the conditional format to work with null dates.

### What was happening
* It seems that prior to 1911 time zones were different from today. Javascript respects these rules, so whenever we compared dates from 1900 (null date) a weird timezone was being applied, making it impossible to compare the values and apply conditional format.

### What was done
* Adjusted the dates have the correct timezone applied on dates prior to 1911;

### Test Steps
1. Open sample
2. Set dates on the first row according to column headers. Eg.: Column Header Null Date -> 01/01/1900


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
