### PR TITLE
RGRIDT-1037: Checkbox column was being affected by css

### DIFF
--- a/code/styles/Grid.css
+++ b/code/styles/Grid.css
@@ -167,7 +167,7 @@
     width: 100%;
 }
 
-.wj-flexgrid .wj-cell label:before {
+.wj-flexgrid .wj-header.wj-cell label:before {
     content: '';
     bottom: 0;
     right: 0;


### PR DESCRIPTION

### What was happening
* Checkbox column had 'fat-finger' applied as well.

### What was done
* Adjusted CSS so only checkbox from row header has 'fat-finger'

### Test Steps
1. Fat-finger row header checkbox.
2. Row should be checked/unchecked

1. Fat-finger checkbox from the column.
2. Nothing should happen.

### Checklist
* [x] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint
