### PR TITLE
RGRIDT-1040: Adding GetCheckedRowsData 

### DIFF
--- a/code/src/GridAPI/Selection.ts
+++ b/code/src/GridAPI/Selection.ts
@@ -34,6 +34,25 @@ namespace GridAPI.Selection {
         );
     }
 
+    export function GetCheckedRowsData(gridID: string): string {
+        PerformanceAPI.SetMark('Selection.GetCheckedRowsData');
+
+        if (!OSFramework.Helper.IsGridReady(gridID)) return '[]';
+        const grid = GridManager.GetGridById(gridID);
+
+        PerformanceAPI.SetMark('Selection.GetCheckedRowsData-end');
+        PerformanceAPI.GetMeasure(
+            '@datagrid-Selection.GetCheckedRowsData',
+            'Selection.GetCheckedRowsData',
+            'Selection.GetCheckedRowsData-end'
+        );
+        return JSON.stringify(
+            grid.features.selection
+                .getCheckedRowsData()
+                .map((p) => p.serialize())
+        );
+    }
+
     export function GetSelectedRowsCount(gridID: string): number {
         PerformanceAPI.SetMark('Selection.GetSelectedRowsCount');
 

--- a/code/src/OSFramework/Feature/ISelection.ts
+++ b/code/src/OSFramework/Feature/ISelection.ts
@@ -48,6 +48,11 @@ namespace OSFramework.Feature {
         getAllSelectionsData(): OSStructure.RowData[];
 
         /**
+         * Returns the Data of the checked rows
+         */
+        getCheckedRowsData(): OSStructure.CheckedRowData[];
+
+        /**
          * Returns the Indexes of the selected rows
          */
         getSelectedRows(): number[];

--- a/code/src/OSFramework/OSStructure/RowData.ts
+++ b/code/src/OSFramework/OSStructure/RowData.ts
@@ -39,4 +39,31 @@ namespace OSFramework.OSStructure {
             };
         }
     }
+
+    export class CheckedRowData implements Interface.ISerializable {
+        private _grid: Grid.IGrid;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        public dataItem: any;
+
+        /**
+         * Represent Checked Row data
+         * @param dataItem Full data source of that row
+         */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(
+            grid: Grid.IGrid,
+            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+            dataItem: any
+        ) {
+            this._grid = grid;
+            this.dataItem = dataItem;
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        public serialize(): any {
+            return {
+                dataItem: this._grid.dataSource.toOSFormat(this.dataItem)
+            };
+        }
+    }
 }

--- a/code/src/WijmoProvider/Features/Selection.ts
+++ b/code/src/WijmoProvider/Features/Selection.ts
@@ -12,7 +12,7 @@ namespace WijmoProvider.Feature {
     {
         private _grid: Grid.IGridWijmo;
         private _hasSelectors: boolean;
-        private readonly _internalLabel = '__checkedPages';
+        private readonly _internalLabel = '__rowSelection';
         private _metadata: OSFramework.Interface.IRowMetadata;
         private _selectionMode: wijmo.grid.SelectionMode;
 
@@ -284,6 +284,23 @@ namespace WijmoProvider.Feature {
 
             rowColumn.clear();
             return rowColumnArr;
+        }
+
+        public getCheckedRowsData(): OSFramework.OSStructure.CheckedRowData[] {
+            const allCheckedRows =
+                this._grid.provider.itemsSource.sourceCollection.filter(
+                    (item) =>
+                        item?.__osRowMetadata?.get(this._internalLabel)
+                            .isChecked === true
+                );
+
+            return allCheckedRows.map(
+                (dataItem) =>
+                    new OSFramework.OSStructure.CheckedRowData(
+                        this._grid,
+                        dataItem
+                    )
+            );
         }
 
         public getMetadata(


### PR DESCRIPTION
### What was done
* Added new GetCheckedRowsData API method.
* Created new CheckedRowData OSStructure, since checked rows don't have row index.

### Test Steps
1. Check a row on the first page 
2. Change pages
3. Check another row
4. Press the GetCheckedRowsData button

Expected: Both rows' data should appear.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
