### PR TITLE
RGRIDT-1062: Equalize selection was working when we had checked rows.

### DIFF
--- a/code/src/OSFramework/Feature/ISelection.ts
+++ b/code/src/OSFramework/Feature/ISelection.ts
@@ -70,6 +70,11 @@ namespace OSFramework.Feature {
         getSelectedRowsData(): OSStructure.RowData[];
 
         /**
+         * Checks if there is any checked row on the grid
+         */
+        hasCheckedRows(): boolean;
+
+        /**
          * Checks if there is a row selected on the grid
          */
         hasSelectedRows(): boolean;

--- a/code/src/WijmoProvider/Features/Selection.ts
+++ b/code/src/WijmoProvider/Features/Selection.ts
@@ -146,7 +146,7 @@ namespace WijmoProvider.Feature {
         }
 
         public equalizeSelection(): OSFramework.OSStructure.CellRange[] {
-            //This method just makes sense for MultiRange and for grid's without checked rows
+            //This method just makes sense for MultiRange or for grid's without checked rows
             if (
                 this._grid.provider.selectionMode !==
                     wijmo.grid.SelectionMode.MultiRange ||

--- a/code/src/WijmoProvider/Features/Selection.ts
+++ b/code/src/WijmoProvider/Features/Selection.ts
@@ -146,10 +146,11 @@ namespace WijmoProvider.Feature {
         }
 
         public equalizeSelection(): OSFramework.OSStructure.CellRange[] {
-            //This method just makes sense for MultiRange
+            //This method just makes sense for MultiRange and for grid's without checked rows
             if (
                 this._grid.provider.selectionMode !==
-                wijmo.grid.SelectionMode.MultiRange
+                    wijmo.grid.SelectionMode.MultiRange ||
+                this.hasCheckedRows()
             )
                 return;
             const grid = this._grid.provider; //Auxiliar for grid
@@ -402,6 +403,10 @@ namespace WijmoProvider.Feature {
                         this._grid.provider.rows[rowIndex].dataItem
                     )
             );
+        }
+
+        public hasCheckedRows(): boolean {
+            return this.getCheckedRowsData().length > 0;
         }
 
         public hasMetadata(rowNumber: number): boolean {


### PR DESCRIPTION
Limiting equalizeSelection to work only if grid doesn't have checked rows


### What was happening
* Since we decided to follow wijmo's behavior (only copy checked content) when dealing with Copy, checkbox, and cell selection, whenever we tried to copy data from a grid that had checked rows and cell selection, the grid was equalizing the selection, but when we pasted the content, only the checked row was there. This was misleading, as it seemed everything would be copied.
![equalize](https://user-images.githubusercontent.com/3113318/141114051-9259720f-3ecc-4adc-b3a2-eb9954959bfb.gif)



### What was done
* Added an extra condition on equalizeSelection method to check if grid has checked rows. If it does, we don't want to equalize.

### Test Steps
1. On Grid's without checkbox, select a cell from one column and then select a cell from a different row and column.
2. Press control C
3. Grid should have equalized the selection

1. On Grid's with checkbox, select a cell from one column and then select a cell from a different row and column.
2. Press control C
3. Grid should have equalized the selection

1. On Grid's with checkbox, select a cell from one column and then select a different row using the checkbox.
2. Press control C
3. Grid should have not equalized the selection


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint

