### PR TITLE
RGRIDT-1079: Adding conditional format to dropdown

### DIFF
--- a/code/src/OSFramework/Configuration/Column/ColumnConfigDropdown.ts
+++ b/code/src/OSFramework/Configuration/Column/ColumnConfigDropdown.ts
@@ -3,7 +3,7 @@ namespace OSFramework.Configuration.Column {
     /**
      * Defines the configuration for Dropdown custom editors
      */
-    export class ColumnConfigDropdown extends ColumnConfig {
+    export class ColumnConfigDropdown extends ColumnConfigConditionalFormat {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public dataMap: any;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -14,7 +14,7 @@ namespace OSFramework.Configuration.Column {
 
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         constructor(config: any, extra: any) {
-            super(config);
+            super(config, extra);
             this.dataMap = undefined;
             this.dropdownOptions = extra.datamap;
             this.parentBinding = extra.parentBinding;

--- a/code/src/WijmoProvider/Features/ConditionalFormat.ts
+++ b/code/src/WijmoProvider/Features/ConditionalFormat.ts
@@ -191,25 +191,23 @@ namespace WijmoProvider.Feature {
 
             s.rows.forEach((row, index) => {
                 columns.forEach((column) => {
-                    const colBinding = column.config.binding.split('.');
-                    let value = row.dataItem;
-                    for (let i = 0; i < colBinding.length; i++) {
-                        // in case we get undefined we want to break
-                        if (
-                            value === undefined &&
-                            i === colBinding.length - 1
-                        ) {
-                            break;
-                        }
-                        value = value[colBinding[i]];
-                    }
+                    const isDropdown =
+                        column.columnType ===
+                        OSFramework.Enum.ColumnType.Dropdown;
+                    const colIndex = this._grid.provider.columns.find(
+                        (x) => x.binding === column.provider.binding
+                    ).index;
+                    const value = this._grid.provider.getCellData(
+                        index,
+                        colIndex,
+                        isDropdown // on dropdown columns we want formatted value
+                    );
+
                     this._mappedRules
                         .get(column.config.binding)
                         .execute(this._grid, value, {
                             row: index,
-                            col: this._grid.provider.columns.find(
-                                (x) => x.binding === column.provider.binding
-                            ).index
+                            col: colIndex
                         });
                 });
             });


### PR DESCRIPTION
This PR adds conditional format to dropdown columns.


### What was happening
* There was no conditional format for dropdown columns

### What was done
* Added conditional format for dropdown columns
* Changed way value is passed for conditional format evaluation.

### Test Steps
1. Dropdown Cells containing 'phone' should have background-red .
2. If you change the Dropdown class input to background-blue, the cells should change as well.

