### PR TITLE
RGRIDT-1065: Adding checkbox conditional format

### DIFF
--- a/code/src/OSFramework/Configuration/Column/ColumnConfigCheckbox.ts
+++ b/code/src/OSFramework/Configuration/Column/ColumnConfigCheckbox.ts
@@ -1,0 +1,19 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Configuration.Column {
+    /**
+     * Defines the configuration for Text Columns
+     */
+    export class ColumnConfigCheckbox extends ColumnConfigConditionalFormat {
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+        constructor(config: any, extra: any) {
+            super(config, extra);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        public getProviderConfig(): any {
+            const config = super.getProviderConfig();
+
+            return config;
+        }
+    }
+}

--- a/code/src/WijmoProvider/Columns/CheckboxColumn.ts
+++ b/code/src/WijmoProvider/Columns/CheckboxColumn.ts
@@ -1,15 +1,19 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace WijmoProvider.Column {
-    export class CheckboxColumn extends AbstractProviderColumn<OSFramework.Configuration.Column.ColumnConfig> {
+    export class CheckboxColumn extends AbstractProviderColumn<OSFramework.Configuration.Column.ColumnConfigCheckbox> {
         constructor(
             grid: OSFramework.Grid.IGrid,
             columnID: string,
-            configs: JSON
+            configs: JSON,
+            extraConfig: JSON
         ) {
             super(
                 grid,
                 columnID,
-                new OSFramework.Configuration.Column.ColumnConfig(configs)
+                new OSFramework.Configuration.Column.ColumnConfigCheckbox(
+                    configs,
+                    extraConfig
+                )
             );
             this._columnEvents =
                 new OSFramework.Event.Column.ColumnEventsManager(this);

--- a/code/src/WijmoProvider/Columns/Factory.ts
+++ b/code/src/WijmoProvider/Columns/Factory.ts
@@ -12,7 +12,12 @@ namespace WijmoProvider.Column {
                 case OSFramework.Enum.ColumnType.Action:
                     return new ActionColumn(grid, columnID, configs);
                 case OSFramework.Enum.ColumnType.Checkbox:
-                    return new CheckboxColumn(grid, columnID, configs);
+                    return new CheckboxColumn(
+                        grid,
+                        columnID,
+                        configs,
+                        extraConfigs
+                    );
                 case OSFramework.Enum.ColumnType.Currency:
                     return new CurrencyColumn(
                         grid,


### PR DESCRIPTION
This PR  adds format to dropdown columns.

### What was happening
There was no conditional format for dropdown columns

### What was done
- Added conditional format for checkbox columns
- Changed way value is passed for conditional format evaluation.

### Test Steps
1. Checkbox Cells containing true should have background-green.
2. If you change the Checkbox class input to background-blue, the cells should change as well.
