### PR TITLE
RGRIDT-1093: Setting node specific versions

### DIFF
--- a/jobs/azure-pipelines-template.yml
+++ b/jobs/azure-pipelines-template.yml
@@ -14,6 +14,11 @@ parameters:
     type: string
 
 steps:
+  #Set Node version
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '^10 || ^12 || ^14'
+
   #Format branch name
   - task: PowerShell@2
     displayName: 'Format branch name'


### PR DESCRIPTION
Recently, Azure started using Node v16 as default. This change broke our tests pipeline because a library called jasmine only works for versions prior to 14. 

### What was done
* Defined specific node versions to be used on pipeline
