### PR TITLE
RGRIDT-1099: GetChangedLines throw errors on empty Grid that has multiple entities

### DIFF
--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -247,9 +247,7 @@ namespace OSFramework.Grid {
             this._metadata = dataJson.metadata;
 
             this._isSingleEntity =
-                Object.keys(
-                    this._metadata || dataJson[0] || dataJson.data[0] || {}
-                ).length <= 1;
+                Object.keys(this._metadata || dataJson[0] || {}).length <= 1;
 
             if (this.hasMetadata) {
                 this._ds = [...dataJson.data];

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -247,7 +247,9 @@ namespace OSFramework.Grid {
             this._metadata = dataJson.metadata;
 
             this._isSingleEntity =
-                Object.keys(dataJson[0] || dataJson.data[0] || {}).length <= 1;
+                Object.keys(
+                    this._metadata || dataJson[0] || dataJson.data[0] || {}
+                ).length <= 1;
 
             if (this.hasMetadata) {
                 this._ds = [...dataJson.data];


### PR DESCRIPTION
This PR fixes IsSingleEntity returning wrong value on empty grids with multiple entities.

### What was happening
* Empty grids with multiple entities were considered to be single entity.

### What was done
* Check metadata keys to determine if grid is single entity or not.

