### PR TITLE
RGRIDT-757: Fixing undo/redo on delete row

### DIFF
--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -157,16 +157,20 @@ namespace WijmoProvider.Feature {
             if (action.dataItem === undefined) return;
 
             const binding = this._grid.provider.getColumn(action.col).binding;
-            const oldValue = this._grid.features.dirtyMark.getOldValue(
-                action.row,
-                binding
-            );
-            this._triggerEventsFromColumn(
-                action.row,
-                binding,
-                oldValue,
-                action._newState
-            );
+
+            // we don't want to redo on GridRemoveRowAction
+            if (typeof action._oldState !== 'object') {
+                const oldValue = this._grid.features.dirtyMark.getOldValue(
+                    action.row,
+                    binding
+                );
+                this._triggerEventsFromColumn(
+                    action.row,
+                    binding,
+                    oldValue,
+                    action._newState
+                );
+            }
         }
 
         /**
@@ -282,16 +286,20 @@ namespace WijmoProvider.Feature {
             if (action.dataItem === undefined) return;
 
             const binding = this._grid.provider.getColumn(action.col).binding;
-            const oldValue = this._grid.features.dirtyMark.getOldValue(
-                action.row,
-                binding
-            );
-            this._triggerEventsFromColumn(
-                action.row,
-                binding,
-                oldValue,
-                action._oldState
-            );
+
+            // we don't want to undo on GridRemoveRowAction
+            if (typeof action._oldState !== 'object') {
+                const oldValue = this._grid.features.dirtyMark.getOldValue(
+                    action.row,
+                    binding
+                );
+                this._triggerEventsFromColumn(
+                    action.row,
+                    binding,
+                    oldValue,
+                    action._oldState
+                );
+            }
         }
 
         private _validateMetadata(

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -154,12 +154,14 @@ namespace WijmoProvider.Feature {
             const action: any = e.action;
 
             // we only want to redo on GridEditAction
-            if (action.dataItem === undefined) return;
-
-            const binding = this._grid.provider.getColumn(action.col).binding;
-
             // we don't want to redo on GridRemoveRowAction
-            if (typeof action._oldState !== 'object') {
+            if (
+                action.dataItem !== undefined &&
+                typeof action._oldState !== 'object'
+            ) {
+                const binding = this._grid.provider.getColumn(
+                    action.col
+                ).binding;
                 const oldValue = this._grid.features.dirtyMark.getOldValue(
                     action.row,
                     binding
@@ -283,12 +285,14 @@ namespace WijmoProvider.Feature {
             const action: any = e.action;
 
             // we only want to undo on GridEditAction
-            if (action.dataItem === undefined) return;
-
-            const binding = this._grid.provider.getColumn(action.col).binding;
-
             // we don't want to undo on GridRemoveRowAction
-            if (typeof action._oldState !== 'object') {
+            if (
+                action.dataItem !== undefined &&
+                typeof action._oldState !== 'object'
+            ) {
+                const binding = this._grid.provider.getColumn(
+                    action.col
+                ).binding;
                 const oldValue = this._grid.features.dirtyMark.getOldValue(
                     action.row,
                     binding


### PR DESCRIPTION
This PR fixes a bug where an error was thrown when we used undo/redo after deleting rows.

### What was happening
* When we used undo/redo after deleting rows, the Validation mark feature was being triggered with the row object. This lead to multiple errors.

### What was done
* Added a condition on Validation mark undo/redo handlers to check whether or not the old state was an object. 

### Test Steps
1. Select rows
2. Press remove select rows
3. Press ctrl z
4. Press ctrl y

Expected result: Rows should have been deleted and no error should be thrown on the console.


