### PR TITLE
RGRIDT-1098: Adding new data change event

### DIFF
--- a/code/src/OSFramework/Event/Grid/GridEventType.enum.ts
+++ b/code/src/OSFramework/Event/Grid/GridEventType.enum.ts
@@ -10,6 +10,7 @@ namespace OSFramework.Event.Grid {
         Initialized = 'Initialized',
         OnFiltersChange = 'OnFiltersChange',
         OnSortChange = 'OnSortChange',
+        OnDataChange = 'OnDataChange',
         SearchEnded = 'SearchEnded'
     }
 }

--- a/code/src/OSFramework/Event/Grid/GridEventsManager.ts
+++ b/code/src/OSFramework/Event/Grid/GridEventsManager.ts
@@ -36,6 +36,9 @@ namespace OSFramework.Event.Grid {
                 case GridEventType.SearchEnded:
                     event = new GridSearchEndEvent();
                     break;
+                case GridEventType.OnDataChange:
+                    event = new GridOnDataChangeEvent();
+                    break;
                 default:
                     throw `The event '${eventType}' is not supported in a grid`;
                     break;

--- a/code/src/OSFramework/Event/Grid/GridOnDataChangeEvent.ts
+++ b/code/src/OSFramework/Event/Grid/GridOnDataChangeEvent.ts
@@ -1,0 +1,37 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Event.Grid {
+    /**
+     *Class that represents the Data Change event.
+     *
+     * @export
+     * @class GridOnDataChangeEvent
+     * @extends {AbstractGridEvent}
+     */
+    export class GridOnDataChangeEvent extends AbstractGridEvent {
+        /**
+         * Method that will trigger the event with the correct parameters.
+         *
+         * @param gridObj grid that is raising the event
+         * @param gridID id of the grid that is raising the event
+         * @param dataChanges changes that happened on grid
+         */
+        public trigger(
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            gridObj: OSFramework.Grid.IGrid,
+            gridID: string,
+            dataChanges: OSStructure.DataChanges
+        ): void {
+            const serializedDataChanges = JSON.stringify(dataChanges);
+            this.handlers
+                .slice(0)
+                .forEach((h) =>
+                    Helper.AsyncInvocation(
+                        h,
+                        gridID,
+                        gridObj,
+                        serializedDataChanges
+                    )
+                );
+        }
+    }
+}

--- a/code/src/OSFramework/OSStructure/DataChanges.ts
+++ b/code/src/OSFramework/OSStructure/DataChanges.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.OSStructure {
+    export class DataChanges {
+        public changedRows: any;
+        public totalRows: number;
+    }
+}

--- a/code/src/OSFramework/OSStructure/DataChanges.ts
+++ b/code/src/OSFramework/OSStructure/DataChanges.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSStructure {
     export class DataChanges {
-        public changedRows: any;
+        public changedRows: unknown;
         public totalRows: number;
     }
 }

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -228,6 +228,24 @@ namespace WijmoProvider.Feature {
 
             // Make sure the count of rows is correct after adding rows.
             if (this._getRowsCount() === expectedRowCount) {
+                if (
+                    this._grid.gridEvents.hasHandlers(
+                        OSFramework.Event.Grid.GridEventType.OnDataChange
+                    )
+                ) {
+                    const dataChanges =
+                        new OSFramework.OSStructure.DataChanges();
+
+                    dataChanges.changedRows = items;
+                    dataChanges.totalRows = this._getRowsCount();
+
+                    this._grid.gridEvents.trigger(
+                        OSFramework.Event.Grid.GridEventType.OnDataChange,
+                        this._grid,
+                        dataChanges
+                    );
+                }
+
                 // Return success
                 return {
                     message: 'Success',
@@ -348,6 +366,8 @@ namespace WijmoProvider.Feature {
             // In case of Undo action, the user will not need to click on the grid to undo.
             providerGrid.focus();
 
+            const deletedRowsList = [];
+
             dataSource.deferUpdate(() => {
                 selRanges.forEach((range) => {
                     for (
@@ -362,6 +382,7 @@ namespace WijmoProvider.Feature {
                                 new wijmo.grid.CellRange(row, -1)
                             )
                         );
+                        deletedRowsList.push(providerGrid.rows[row].dataItem);
                         // Remove the data item from the editable collection view.
                         dataSource.remove(providerGrid.rows[row].dataItem);
                         // Removed rows should be valid
@@ -378,6 +399,24 @@ namespace WijmoProvider.Feature {
 
             // Make sure the count of rows is correct after removing rows.
             if (this._getRowsCount() === expectedRowCount) {
+                if (
+                    this._grid.gridEvents.hasHandlers(
+                        OSFramework.Event.Grid.GridEventType.OnDataChange
+                    )
+                ) {
+                    const dataChanges =
+                        new OSFramework.OSStructure.DataChanges();
+
+                    dataChanges.changedRows = deletedRowsList;
+                    dataChanges.totalRows = this._getRowsCount();
+
+                    this._grid.gridEvents.trigger(
+                        OSFramework.Event.Grid.GridEventType.OnDataChange,
+                        this._grid,
+                        dataChanges
+                    );
+                }
+
                 return {
                     message: 'Success',
                     isSuccess: true,


### PR DESCRIPTION
This PR adds OnDataChange event that is triggered whenever a row is added/deleted, returning, for now, the total number of rows the grid has.


### What was happening
* On an empty grid, the  “We couldn't find any data to show here”  was always shown, even if the user added a new row.

### What was done
* Added a new Event that is triggered whenever a row is added/deleted, returning, for now, the total number of rows the grid has.
* Used the returning value to update HasData attribute on our grid.

### Test Steps
1. Add row

Expected:  “We couldn't find any data to show here” should disappear.

1. Add row.
2. Delete row.

Expected: “We couldn't find any data to show here” should be displayed

