### PR TITLE
RGRIDT-1115: Fixing is required on date columns

### DIFF
--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -76,8 +76,8 @@ namespace WijmoProvider.Feature {
                         //Even when converted to String because after edition the cells from the Dropdown Columns will have the value in string format and before edition the value of those same cells can be integers (number identifiers).
                         return (
                             originalValue !== cellValue &&
-                            originalValue.toString() !== cellValue &&
-                            originalValue.toString() !== cellValue.toString() // compare date objects as well
+                            originalValue.toString() !==
+                                (cellValue && cellValue.toString()) // compare date objects as well
                         );
                     }
                 }
@@ -116,8 +116,8 @@ namespace WijmoProvider.Feature {
                         //Even when converted to String because after edition the cells from the Dropdown Columns will have the value in string format and before edition the value of those same cells can be integers (number identifiers).
                         if (
                             originalValue === cellValue ||
-                            originalValue.toString() === cellValue ||
-                            originalValue.toString() === cellValue.toString() // compare date objects as well
+                            originalValue.toString() ===
+                                (cellValue && cellValue.toString()) // compare date objects as well
                         ) {
                             //Add 1 to the notDirtyCells
                             notDirtyCells++;


### PR DESCRIPTION
This PR fixes a bug when deleting a is required date column.


### What was happening
* There was a [bug ](https://www.outsystems.com/forums/discussion/75258/data-grid-reactive-console-error-when-isrequired-property-for-date-datetime-c/) reported on forum. Whenever we have isRequired on Date/Datetime columns, cell deletion would throw an error.

### What was done
* Adjusted isDirtyMark logic

### Test Steps
1.  To focus/select the cell, click on any Date  column which has value.
2. Press Delete key from keyboard.
  