### PR TITLE
RGRIDT-1097: Adding SetColumnFilterOptions

### DIFF
--- a/code/src/GridAPI/Filter.ts
+++ b/code/src/GridAPI/Filter.ts
@@ -178,4 +178,39 @@ namespace GridAPI.Filter {
             'Filter.ByValue-end'
         );
     }
+
+    /**
+     * Function that sets column filter options
+     *
+     * @export
+     * @param {string} gridID ID of the Grid block.
+     * @param {string} columnID ID of the column block where the filter options will be set.
+     * @param {string} options  Values that will be used on filter by value list.
+     * @param {number} maxVisibleOptions Maximum number of elements on the filter list of display values.
+     * @returns {*}  {void}
+     */
+    export function SetColumnFilterOptions(
+        gridID: string,
+        columnID: string,
+        options: string,
+        maxVisibleOptions?: number
+    ): void {
+        PerformanceAPI.SetMark('Filter.SetColumnFilterOptions');
+
+        if (!OSFramework.Helper.IsGridReady(gridID)) return;
+        const grid = GridManager.GetGridById(gridID);
+
+        grid.features.filter.setColumnFilterOptions(
+            columnID,
+            JSON.parse(options),
+            maxVisibleOptions
+        );
+
+        PerformanceAPI.SetMark('Filter.SetColumnFilterOptions-end');
+        PerformanceAPI.GetMeasure(
+            '@datagrid-Filter.SetColumnFilterOptions',
+            'Filter.SetColumnFilterOptions',
+            'Filter.SetColumnFilterOptions-end'
+        );
+    }
 }

--- a/code/src/OSFramework/Feature/IColumnFilter.ts
+++ b/code/src/OSFramework/Feature/IColumnFilter.ts
@@ -18,5 +18,10 @@ namespace OSFramework.Feature {
         ): void;
         clear(columnID: string): void;
         deactivate(columnID: string): void;
+        setColumnFilterOptions(
+            columnID: string,
+            options: Array<string>,
+            maxVisibleOptions?: number
+        ): void;
     }
 }

--- a/code/src/WijmoProvider/Features/ColumnFilter.ts
+++ b/code/src/WijmoProvider/Features/ColumnFilter.ts
@@ -216,7 +216,7 @@ namespace WijmoProvider.Feature {
                     new Set<string>(options) // we only want unique values
                 );
 
-                if (maxVisibleOptions)
+                if (maxVisibleOptions > 0)
                     this._filter.getColumnFilter(
                         column.provider
                     ).valueFilter.maxValues = maxVisibleOptions;

--- a/code/src/WijmoProvider/Features/ColumnFilter.ts
+++ b/code/src/WijmoProvider/Features/ColumnFilter.ts
@@ -74,9 +74,7 @@ namespace WijmoProvider.Feature {
         }
 
         public get filterType(): wijmo.grid.filter.FilterType {
-            return this._grid.config.serverSidePagination
-                ? wijmo.grid.filter.FilterType.Condition
-                : wijmo.grid.filter.FilterType.Both;
+            return wijmo.grid.filter.FilterType.Both;
         }
 
         public activate(columnID: string): void {
@@ -198,6 +196,35 @@ namespace WijmoProvider.Feature {
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         public getViewLayout(): any {
             return this._filter.filterDefinition;
+        }
+
+        public setColumnFilterOptions(
+            columnID: string,
+            options: Array<string>,
+            maxVisibleOptions?: number
+        ): void {
+            const column = this._grid.getColumn(columnID);
+
+            // for now we only want this to work on text or dropdown columns
+            if (
+                column.columnType === OSFramework.Enum.ColumnType.Text ||
+                column.columnType === OSFramework.Enum.ColumnType.Dropdown
+            ) {
+                this._filter.getColumnFilter(
+                    column.provider
+                ).valueFilter.uniqueValues = Array.from(
+                    new Set<string>(options) // we only want unique values
+                );
+
+                if (maxVisibleOptions)
+                    this._filter.getColumnFilter(
+                        column.provider
+                    ).valueFilter.maxValues = maxVisibleOptions;
+            } else {
+                throw new Error(
+                    `The SetColumnFilterOptions client action can only be applied to Text or Dropdowncolumns.`
+                );
+            }
         }
 
         public setState(value: boolean): void {

--- a/code/src/WijmoProvider/Helper/FilterFactory.ts
+++ b/code/src/WijmoProvider/Helper/FilterFactory.ts
@@ -88,7 +88,9 @@ namespace WijmoProvider.Helper.FilterFactory {
             .filter(
                 (activeFilters) =>
                     activeFilters.type === 'condition' ||
-                    activeFilters.type === 'value'
+                    // when we change filter uniqueValues this event gets triggered with showValues being null
+                    // we only want to call the added handler if we have showValues defined
+                    (activeFilters.type === 'value' && activeFilters.showValues)
             )
             .forEach((filter) => {
                 const activeFilter = new OSFramework.OSStructure.ActiveFilter();


### PR DESCRIPTION
This PR adds a client action that will allow grids with server-side pagination to filter text/dropdown columns by value. The client action will populate the filter list with all possible values.

### Test Steps
1. Filter text column by value.
2. All unique values should be displayed.
3. Select a value.

Expected: Filter should work

1. Filter dropdown column by value.
2. All unique values should be displayed.
3. Select a value.

Expected: Filter should work



