### PR TITLE
RGRIDT-1097: Filter by value fix

### DIFF
--- a/code/src/WijmoProvider/Features/ColumnFilter.ts
+++ b/code/src/WijmoProvider/Features/ColumnFilter.ts
@@ -74,7 +74,9 @@ namespace WijmoProvider.Feature {
         }
 
         public get filterType(): wijmo.grid.filter.FilterType {
-            return wijmo.grid.filter.FilterType.Both;
+            return this._grid.config.serverSidePagination
+                ? wijmo.grid.filter.FilterType.Condition
+                : wijmo.grid.filter.FilterType.Both;
         }
 
         public activate(columnID: string): void {
@@ -203,6 +205,11 @@ namespace WijmoProvider.Feature {
             options: Array<string>,
             maxVisibleOptions?: number
         ): void {
+            if (!this._grid.config.serverSidePagination)
+                throw new Error(
+                    'This action is meant to be used on a Grid with server-side pagination ON.'
+                );
+
             const column = this._grid.getColumn(columnID);
 
             // for now we only want this to work on text or dropdown columns
@@ -210,6 +217,12 @@ namespace WijmoProvider.Feature {
                 column.columnType === OSFramework.Enum.ColumnType.Text ||
                 column.columnType === OSFramework.Enum.ColumnType.Dropdown
             ) {
+                // this column will have
+                this.changeFilterType(
+                    columnID,
+                    wijmo.grid.filter.FilterType.Both
+                );
+
                 this._filter.getColumnFilter(
                     column.provider
                 ).valueFilter.uniqueValues = Array.from(


### PR DESCRIPTION
This PR sets default column filter type to condition on server-side grids and changes filter type to Value when calling SetColumnFilterOptions.

[Sample page](url)

### What was happening
* Missed one AC.

### What was done
* Adjusted code to work properly

