### PR TITLE
RGRIDT-1121: Pagination records didn't update

### DIFF
--- a/code/src/WijmoProvider/Features/Pagination.ts
+++ b/code/src/WijmoProvider/Features/Pagination.ts
@@ -58,7 +58,7 @@ namespace WijmoProvider.Feature {
 
             //If we found the placeholder (!== null) and the
             //provider already has a value (!== NaN).
-            if (element && value) {
+            if (element && !isNaN(value)) {
                 //Let's set the value in the placeholder
                 element.textContent = value.toString();
             }
@@ -86,11 +86,11 @@ namespace WijmoProvider.Feature {
         }
 
         public get rowStart(): number {
-            return this.pageIndex * this.pageSize + 1;
+            return this._view.itemCount && this.pageIndex * this.pageSize + 1;
         }
 
         public get rowEnd(): number {
-            return this.rowStart + this._view.itemCount - 1;
+            return this.rowStart && this.rowStart + this._view.itemCount - 1;
         }
 
         /// Retrieve the total number of rows considering all pages


### PR DESCRIPTION
This PR fixes a bug where pagination records didn't update when grid showed no data.

### What was happening
* Whenever the grid didn't display any data, the pagination records were not updating. 
![image](https://user-images.githubusercontent.com/3113318/147915654-c78a4ea1-29b0-4d00-925b-4d536c22170a.png)


### What was done
* Fixed the if condition. We were checking for the page records value explicitly and since it came with 0, which is falsy.
* Adjusted rowStart and rowEnd properties as well.

### Test Steps
-Search for a name already present in the records.
-Check the number of records.
-Search for a name not present in the list of records.
-The number of records should get updated to show 0.


