### PR TITLE
RGRIDT-1122: OnCellChange is sync when column is sorted

### DIFF
--- a/code/src/OSFramework/Event/Column/ColumnEventsManager.ts
+++ b/code/src/OSFramework/Event/Column/ColumnEventsManager.ts
@@ -52,6 +52,10 @@ namespace OSFramework.Event.Column {
         ): void {
             if (this.events.has(eventType)) {
                 const handlerEvent = this.events.get(eventType);
+                // RGRIDT-1122: if column is sorted, we want on cell change event to be handled syncronally, because in some cases our validation happens before sorting occurs.
+                const isAsync = !this._column.grid.features.sort.isColumnSorted(
+                    this._column.widgetId
+                );
 
                 switch (eventType) {
                     case ColumnEventType.ActionClick:
@@ -67,7 +71,8 @@ namespace OSFramework.Event.Column {
                             this._column.widgetId, // ID of the Column block in which the cell value has changed.
                             rowNumber, // Number of the row in which the cell value has changed.
                             oldValue, // Value of the cell before its value has changed (Old)
-                            value // Value of the cell after its value has changed (New)
+                            value, // Value of the cell after its value has changed (New)
+                            isAsync
                         );
                         break;
                     default:

--- a/code/src/OSFramework/Event/Column/OnCellValueChange.ts
+++ b/code/src/OSFramework/Event/Column/OnCellValueChange.ts
@@ -12,11 +12,12 @@ namespace OSFramework.Event.Column {
             columnID: string,
             rowNumber: number,
             oldValue: string,
-            newValue: string
+            newValue: string,
+            isAsync = true
         ): void {
-            this.handlers
-                .slice(0)
-                .forEach((h) =>
+            this.handlers.slice(0).forEach((h) => {
+                // RGRIDT-1122: if column is sorted, we want on cell change event to be handled syncronally, because in some cases our validation happens before sorting occurs.
+                if (isAsync) {
                     Helper.AsyncInvocation(
                         h,
                         gridID,
@@ -24,8 +25,18 @@ namespace OSFramework.Event.Column {
                         columnID,
                         oldValue,
                         newValue
-                    )
-                );
+                    );
+                } else {
+                    Helper.SyncInvocation(
+                        h,
+                        gridID,
+                        rowNumber,
+                        columnID,
+                        oldValue,
+                        newValue
+                    );
+                }
+            });
         }
     }
 }

--- a/code/src/OSFramework/Feature/IColumnSort.ts
+++ b/code/src/OSFramework/Feature/IColumnSort.ts
@@ -6,6 +6,7 @@ namespace OSFramework.Feature {
             IView {
         isGridSorted: boolean;
         clear(): void;
+        isColumnSorted(columnID: string): boolean;
         sortColumn(columnID: string, ascending: OSStructure.Sorting): void;
     }
 }

--- a/code/src/OSFramework/Helper/AsyncInvocation.ts
+++ b/code/src/OSFramework/Helper/AsyncInvocation.ts
@@ -4,4 +4,8 @@ namespace OSFramework.Helper {
     export function AsyncInvocation(callback: Callbacks.Generic, ...args: any) {
         if (callback) setTimeout(() => callback(...args), 0);
     }
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+    export function SyncInvocation(callback: Callbacks.Generic, ...args: any) {
+        if (callback) callback(...args);
+    }
 }

--- a/code/src/WijmoProvider/Features/ColumnSort.ts
+++ b/code/src/WijmoProvider/Features/ColumnSort.ts
@@ -178,6 +178,18 @@ namespace WijmoProvider.Feature {
             );
         }
 
+        public isColumnSorted(columnID: string): boolean {
+            const column = this._grid.getColumn(columnID);
+
+            if (!column) return false;
+
+            return (
+                this._grid.provider.itemsSource.sortDescriptions.find(
+                    (col) => col.property === column.config.binding
+                ) !== undefined
+            );
+        }
+
         public setState(value: boolean): void {
             this._grid.provider.allowSorting = value
                 ? wijmo.grid.AllowSorting.MultiColumn


### PR DESCRIPTION
This PR adds a new way to handle onCellChange event when a column is sorted.

### What was happening
* Whenever we had a column sorted and did some validation on the cellChange event, the validation mark was misplaced. This happened because we handled the callback async, which means that our validation happened after Wijmo's sort event.

### What was done
* Created a new method to see if the column is sorted.
* Check if the current cell's column being changed is sorted, if it is we handle the callback in a sync way, otherwise we handle it async (default way)

### Test Steps
1. Sort the Price column

2. Change the value (must be inferior to 100)

3. The reorder is made

Expected: The error is being presented on the line where our new value was reordered


