### PR TITLE
ROU-2948: Fixing action column link not working on IOS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bmartinho @glundgren93 @rugoncalves @tmbp95 @JoaoFerreira-FrontEnd
+* @bmartinho @glundgren93 @rugoncalves @tmbp95 @JoaoFerreira-FrontEnd @joselrio @BenOsodrac @joanabpereira @bmarcelino-fe @gnbm

--- a/code/src/OSFramework/Configuration/Column/ColumnConfig.ts
+++ b/code/src/OSFramework/Configuration/Column/ColumnConfig.ts
@@ -39,7 +39,7 @@ namespace OSFramework.Configuration.Column {
         // eslint-disable-next-line
         constructor(config: any) {
             // Remove any {} or [] that exist on the binding. In order to accept any format "{EntityName}.[FieldName]" or "EntityName.FieldName"
-            config.binding = config.binding.replaceAll(/[{}[\]]+/g, '');
+            config.binding = config.binding.replace(/[{}[\]]+/g, '');
             super(config);
         }
 

--- a/code/styles/Grid.css
+++ b/code/styles/Grid.css
@@ -289,7 +289,7 @@
     background: var(--datagrid-cell-background);
 }
 
-.wj-cells .wj-cell[aria-readonly='true']:not(.wj-group) *:not(.wj-cell-maker) {
+.wj-cells .wj-cell[aria-readonly='true']:not(.wj-group) > *:not(.wj-cell-maker){
     pointer-events: none;
 }
 


### PR DESCRIPTION
This PR fixes two bugs that happened on IOS devices. One of them is that action columns with fixed text containing HTML elements were not being clicked. The other is that Grid was not being rendered on IOS versions prior to 13.4, [due to replaceAll not being supported](https://caniuse.com/?search=replaceAll)

### What was done
* Adjusted CSS to support Action Column HTML elements on fixed text.
* Changed ReplaceAll to replace

### Test Steps
1. Open sample on IOS device
2. Click on a pencil on any row
3. The Raw data table should be filled with data from the clicked row.

###
1. Open sample on IOS device with version prior to 13.4
2. Grid should render


