### PR TITLE
ROU-2907: Adjusting ValidateRow method

### DIFF
--- a/code/src/GridAPI/Cells.ts
+++ b/code/src/GridAPI/Cells.ts
@@ -72,18 +72,25 @@ namespace GridAPI.Cells {
      * @param {string} gridID ID of the Grid.
      * @param {number} rowIndex Index of the row that contains the cells to be validated.
      */
-    export function ValidateRow(gridID: string, rowIndex: number): void {
+    export function ValidateRow(gridID: string, rowIndex: number): string {
         PerformanceAPI.SetMark('Cells.validateRow');
 
-        GridManager.GetGridById(gridID).features.validationMark.validateRow(
-            rowIndex
+        let output = '';
+
+        output = JSON.stringify(
+            GridManager.GetGridById(gridID).features.validationMark.validateRow(
+                rowIndex
+            )
         );
+
         PerformanceAPI.SetMark('Cells.validateRow-end');
         PerformanceAPI.GetMeasure(
             '@datagrid-Cells.validateRow',
             'Cells.validateRow',
             'Cells.validateRow-end'
         );
+
+        return output;
     }
     /**
      * Responsible for updating a specific cell -

--- a/code/src/OSFramework/Enum/ErrorCodes.ts
+++ b/code/src/OSFramework/Enum/ErrorCodes.ts
@@ -13,7 +13,8 @@ namespace OSFramework.Enum {
         API_FailedPaginationSetCurrentPage = 'GRID-API-01002',
         API_UnableToAddRow = 'GRID-API-02001',
         API_FailedAddRow = 'GRID-API-02002',
-        API_UnableToRemoveRow = 'GRID-API-02001',
-        API_FailedRemoveRow = 'GRID-API-02002'
+        API_UnableToRemoveRow = 'GRID-API-02003',
+        API_FailedRemoveRow = 'GRID-API-02004',
+        API_FailedApplyRowValidation = 'GRID-API-02005'
     }
 }

--- a/code/src/OSFramework/Feature/IValidationMark.ts
+++ b/code/src/OSFramework/Feature/IValidationMark.ts
@@ -25,7 +25,7 @@ namespace OSFramework.Feature {
             rowNumber: number,
             column: OSFramework.Column.IColumn
         ): void;
-        validateRow(rowNumber: number): void;
+        validateRow(rowNumber: number): OSFramework.OSStructure.ReturnMessage;
         // clearByRow(row: number): void;
     }
 }

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -608,25 +608,42 @@ namespace WijmoProvider.Feature {
          * Those actions might be included in the OnCellValueChange handler or in case the isMandatory column configuration is set.
          * @param {number} rowNumber Index of the row that contains the cells to be validated.
          */
-        public validateRow(rowNumber: number): void {
-            // Triggers the validation method per column
-            this._grid
-                .getColumns()
-                .forEach((column: OSFramework.Column.IColumn) => {
-                    // This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
-                    const currValue = this._grid.provider.getCellData(
-                        rowNumber,
-                        column.provider.index,
-                        false
-                    );
-                    // Triggers the events of OnCellValueChange associated to a specific column in OS
-                    this._triggerEventsFromColumn(
-                        rowNumber,
-                        column.provider.binding,
-                        currValue,
-                        currValue
-                    );
-                });
+        public validateRow(
+            rowNumber: number
+        ): OSFramework.OSStructure.ReturnMessage {
+            try {
+                // Triggers the validation method per column
+                this._grid
+                    .getColumns()
+                    .forEach((column: OSFramework.Column.IColumn) => {
+                        // This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
+                        const currValue = this._grid.provider.getCellData(
+                            rowNumber,
+                            column.provider.index,
+                            false
+                        );
+                        // Triggers the events of OnCellValueChange associated to a specific column in OS
+                        this._triggerEventsFromColumn(
+                            rowNumber,
+                            column.provider.binding,
+                            currValue,
+                            currValue
+                        );
+                    });
+
+                return {
+                    message: 'Success',
+                    isSuccess: true,
+                    code: OSFramework.Enum.ErrorCodes.GRID_SUCCESS
+                };
+            } catch (error) {
+                return {
+                    code: OSFramework.Enum.ErrorCodes
+                        .API_FailedApplyRowValidation,
+                    message: 'Error',
+                    isSuccess: false
+                };
+            }
         }
     }
 }


### PR DESCRIPTION
This PR is for the new ApplyRowValidations client action. 

### What was done
* Since we already had the ValidateRow method, I only adjusted it to return the proper feedback codes.

### Test Steps
1. Add a new row using the context menu.
2. Press Change Cell Button

Expected: New row should have invalid marks.

