### PR TITLE
ROU-3021: Fixing issue where removedRows would return index

### DIFF
--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -114,7 +114,9 @@ namespace WijmoProvider.Feature {
             // clear existing items, because we want to override them with ours
             collectionView.itemsRemoved.clear();
             collectionView.trackChanges &&
-                collectionView.itemsRemoved.push(...undoableItems);
+                collectionView.itemsRemoved.push(
+                    ...undoableItems.map((undoable) => undoable.item)
+                );
         }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public applyState(state: any) {


### PR DESCRIPTION
This PR fixes an issue where GetChangedLines was returning wrong values on removedRows. This was a side effect introduced on #176 

### What was happening
* RemovedRows was returning datasourceIdx along with the dataItem.

### What was done
* Added only dataItems on collectionView.itemsRemoved.

### Test Steps
1. Select a row
2. Press Remove SelectedRows button
3. Press GetChangedLines button

Expected: The returning JSON should not have datasourceIdx 
