### PR TITLE
ROU-3067: Fixing issue where Add Row would throw error

### DIFF
--- a/code/src/GridAPI/Rows.ts
+++ b/code/src/GridAPI/Rows.ts
@@ -60,12 +60,25 @@ namespace GridAPI.Rows {
      */
     export function AddRows(gridID: string): string {
         PerformanceAPI.SetMark('Rows.AddRows');
+        const responseObj = {
+            isSuccess: true,
+            message: OSFramework.Enum.ErrorMessages.SuccessMessage,
+            code: OSFramework.Enum.ErrorCodes.GRID_SUCCESS
+        };
 
-        const grid = GridManager.GetGridById(gridID);
-        let output = '';
+        if (!OSFramework.Helper.IsGridReady(gridID)) {
+            responseObj.isSuccess = false;
+            responseObj.message = OSFramework.Enum.ErrorMessages.Grid_NotFound;
+            responseObj.code = OSFramework.Enum.ErrorCodes.CFG_GridNotFound;
+            return JSON.stringify(responseObj);
+        }
 
-        if (grid !== undefined) {
-            output = JSON.stringify(grid.features.rows.addNewRows());
+        try {
+            GridManager.GetGridById(gridID).features.rows.addNewRows();
+        } catch (error) {
+            responseObj.isSuccess = false;
+            responseObj.message = error.message;
+            responseObj.code = OSFramework.Enum.ErrorCodes.API_FailedAddRow;
         }
 
         PerformanceAPI.SetMark('Rows.AddRows-end');
@@ -74,7 +87,7 @@ namespace GridAPI.Rows {
             'Rows.AddRows',
             'Rows.AddRows-end'
         );
-        return output;
+        return JSON.stringify(responseObj);
     }
 
     /**

--- a/code/src/OSFramework/Enum/ErrorMessages.ts
+++ b/code/src/OSFramework/Enum/ErrorMessages.ts
@@ -6,6 +6,8 @@ namespace OSFramework.Enum {
     export enum ErrorMessages {
         SuccessMessage = 'Success',
         Grid_NotFound = 'Grid not found',
-        InvalidColumnIdentifier = 'It seems you are not passing a valid column.'
+        InvalidColumnIdentifier = 'It seems you are not passing a valid column.',
+        AddRowWithActiveFilterOrSort = 'It seems that you have an active filter, group or sort on your columns. Remove them and try again.',
+        AddRowErrorMessage = 'An error occurred while trying to add a new row.'
     }
 }

--- a/code/src/OSFramework/Enum/ErrorMessages.ts
+++ b/code/src/OSFramework/Enum/ErrorMessages.ts
@@ -8,6 +8,7 @@ namespace OSFramework.Enum {
         Grid_NotFound = 'Grid not found',
         InvalidColumnIdentifier = 'It seems you are not passing a valid column.',
         AddRowWithActiveFilterOrSort = 'It seems that you have an active filter, group or sort on your columns. Remove them and try again.',
-        AddRowErrorMessage = 'An error occurred while trying to add a new row.'
+        AddRowErrorMessage = 'An error occurred while trying to add a new row.',
+        UnableToAddRow = 'Unable to add row. Please use ArrangeData action to serialize your data.'
     }
 }

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -164,7 +164,15 @@ namespace OSFramework.Grid {
          */
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         protected _parseNewItem(): any {
-            const parsedNewItem = _.cloneDeep(this._metadata);
+            if (!this.hasMetadata && this._ds.length === 0) {
+                throw new Error(
+                    `Unable to add row. Please use ArrangeData action to serialize your data.`
+                );
+            }
+            const parsedNewItem =
+                _.cloneDeep(this._metadata) ||
+                _.cloneDeep(_.omit(this._ds[0], '__osRowMetadata'));
+
             const converter = (object) => {
                 Object.keys(object).forEach((key) => {
                     if (typeof object[key] === 'object') converter(object[key]);

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -165,9 +165,7 @@ namespace OSFramework.Grid {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         protected _parseNewItem(): any {
             if (!this.hasMetadata && this._ds.length === 0) {
-                throw new Error(
-                    `Unable to add row. Please use ArrangeData action to serialize your data.`
-                );
+                throw new Error(Enum.ErrorMessages.UnableToAddRow);
             }
             const parsedNewItem =
                 _.cloneDeep(this._metadata) ||

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -271,15 +271,11 @@ namespace WijmoProvider.Feature {
          * Add a new row to the grid with all cells empty.
          * @returns ReturnMessage containing the resulting code from the adding rows and the error message in case of failure.
          */
-        public addNewRows(): OSFramework.OSStructure.ReturnMessage {
+        public addNewRows(): void {
             if (!this._canAddRows()) {
-                // Return error
-                return {
-                    code: OSFramework.Enum.ErrorCodes.API_UnableToAddRow,
-                    message:
-                        'It seems that you have an active filter, group or sort on your columns. Remove them and try again.',
-                    isSuccess: false
-                };
+                throw new Error(
+                    OSFramework.Enum.ErrorMessages.AddRowWithActiveFilterOrSort
+                );
             }
 
             const providerGrid = this._grid.provider;
@@ -342,19 +338,10 @@ namespace WijmoProvider.Feature {
                         dataChanges
                     );
                 }
-
-                // Return success
-                return {
-                    message: OSFramework.Enum.ErrorMessages.SuccessMessage,
-                    isSuccess: true,
-                    code: OSFramework.Enum.ErrorCodes.GRID_SUCCESS
-                };
             } else {
-                return {
-                    code: OSFramework.Enum.ErrorCodes.API_FailedAddRow,
-                    message: 'Error',
-                    isSuccess: false
-                };
+                throw new Error(
+                    OSFramework.Enum.ErrorMessages.AddRowErrorMessage
+                );
             }
         }
 


### PR DESCRIPTION
This PR fixes a bug on Grids that are not using ArrangeData action to serialize data. Since the grid didn't have metadata, an error was thrown.


### What was done
* If there is no metadata and there is data on our dataSource, retrieve items from the first item of dataSource.

### Test Steps
1. Open the context menu
2. Add a new row

Expected: New row should be added and it all columns should be working properly.



