### PR TITLE
Changing code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bmartinho @glundgren93 @rugoncalves @tmbp95 @JoaoFerreira-FrontEnd @joselrio @BenOsodrac @joanabpereira @bmarcelino-fe @gnbm
+* @glundgren93 @rugoncalves @JoaoFerreira-FrontEnd @joselrio @BenOsodrac @joanabpereira @bmarcelino-fe @gnbm


### PR DESCRIPTION
This is commemoration PR, in which @bmartinho and @tmbp95 will be freed from the responsibility of *owning* this repo.

Their contribution wasn't limited to changes in this repo, for it doesn't reflect everything that makes a software good: thinking, designing, creating, testing the best solutions for the end-user - the developer.

This being said, have the final honor to approve this PR @bmartinho and @tmbp95 !

Good riddance!

![goodbye](https://user-images.githubusercontent.com/10534623/152319413-2f0e049f-41e0-4302-b6d7-f01843acd84f.gif)


