### PR TITLE
ROU-2855: Adding ShowAggregateValue parameter

### DIFF
--- a/code/src/OSFramework/Configuration/Grid/FlexGridConfig.ts
+++ b/code/src/OSFramework/Configuration/Grid/FlexGridConfig.ts
@@ -20,6 +20,7 @@ namespace OSFramework.Configuration.Grid {
         public rowsPerPage: number;
         public selectionMode: number;
         public serverSidePagination: boolean;
+        public showAggregateValues: boolean;
         public uniqueId: string;
         public validateEdits: boolean;
 

--- a/code/src/OSFramework/Configuration/IConfigurationGrid.ts
+++ b/code/src/OSFramework/Configuration/IConfigurationGrid.ts
@@ -19,6 +19,10 @@ namespace OSFramework.Configuration {
         */
         serverSidePagination: boolean;
         /**
+         Indicates if the grid has row footer to show aggregate values
+        */
+        showAggregateValues: boolean;
+        /**
          * Represents the identifier created on OS and used as reference to find objects on screen
          */
         uniqueId: string;

--- a/code/src/OSFramework/Enum/OS_Config_Grid.ts
+++ b/code/src/OSFramework/Enum/OS_Config_Grid.ts
@@ -14,6 +14,7 @@ namespace OSFramework.Enum {
         rowsPerPage,
         selectionMode,
         serverSidePagination,
+        showAggregateValues,
         validateEdits
     }
 }

--- a/code/src/OSFramework/Feature/ExposedFeatures.ts
+++ b/code/src/OSFramework/Feature/ExposedFeatures.ts
@@ -6,6 +6,7 @@ namespace OSFramework.Feature {
         public calculatedField: ICalculatedField;
         public cellData: ICellData;
         public cellStyle: ICellStyle;
+        public columnAggregate: IColumnAggregate;
         public columnFreeze: IColumnFreeze;
         public columnReorder: IColumnReorder;
         public columnResize: IColumnResize;

--- a/code/src/OSFramework/Feature/IColumnAggregate.ts
+++ b/code/src/OSFramework/Feature/IColumnAggregate.ts
@@ -1,0 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Feature {
+    export interface IColumnAggregate
+        extends Interface.IProviderConfig<boolean> {}
+}

--- a/code/src/WijmoProvider/Features/ColumnAggregate.ts
+++ b/code/src/WijmoProvider/Features/ColumnAggregate.ts
@@ -1,0 +1,46 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace WijmoProvider.Feature {
+    // export class Builder extends Validation implements OSFramework.Interface.IBuilder {
+    export class ColumnAggregate
+        implements
+            OSFramework.Feature.IColumnAggregate,
+            OSFramework.Interface.IBuilder
+    {
+        private _aggregateRow: wijmo.grid.GroupRow;
+        private _grid: Grid.IGridWijmo;
+        private _showAggregateValue: boolean;
+
+        constructor(grid: Grid.IGridWijmo, showAggregateValue: boolean) {
+            this._grid = grid;
+            this._showAggregateValue = showAggregateValue;
+        }
+        public build(): void {
+            this.setState(this._showAggregateValue);
+        }
+
+        /**
+         * Function that will add/remove row footer to show aggregate values
+         *
+         * @param value {boolean} True => Adds aggregate footer , False => Removes aggregate footer
+         */
+        public setState(value: boolean): void {
+            if (value) {
+                if (this._aggregateRow === undefined) {
+                    this._aggregateRow = new wijmo.grid.GroupRow();
+                }
+                this._grid.provider.columnFooters.rows.push(this._aggregateRow);
+            } else {
+                const aggregateRow =
+                    this._grid.provider.columnFooters.rows.find(
+                        (row) => row.index === this._aggregateRow.index
+                    );
+
+                // we only want to remove the row, if it exists
+                if (aggregateRow)
+                    GridAPI.GridManager.GetActiveGrid().provider.columnFooters.rows.remove(
+                        aggregateRow
+                    );
+            }
+        }
+    }
+}

--- a/code/src/WijmoProvider/Features/FeatureBuilder.ts
+++ b/code/src/WijmoProvider/Features/FeatureBuilder.ts
@@ -74,6 +74,15 @@ namespace WijmoProvider.Feature {
             this._features.cellStyle = this._makeItem(CellStyle);
             return this;
         }
+
+        private _makeColumnAggregate(enable: boolean): FeatureBuilder {
+            this._features.columnAggregate = this._makeItem(
+                ColumnAggregate,
+                enable
+            );
+            return this;
+        }
+
         private _makeColumnPicker(): FeatureBuilder {
             this._makeItem(ColumnPicker);
             return this;
@@ -224,7 +233,8 @@ namespace WijmoProvider.Feature {
                 ._makeConditionalFormat()
                 ._makeCalculatedField()
                 ._makeRowHeader(config.rowHeader)
-                ._makeColumnPicker();
+                ._makeColumnPicker()
+                ._makeColumnAggregate(config.showAggregateValues);
 
             super.build();
         }

--- a/code/src/WijmoProvider/Grid/FlexGrid.ts
+++ b/code/src/WijmoProvider/Grid/FlexGrid.ts
@@ -155,6 +155,9 @@ namespace WijmoProvider.Grid {
                 case OSFramework.Enum.OS_Config_Grid.selectionMode:
                     this.features.selection.setState(value);
                     return;
+                case OSFramework.Enum.OS_Config_Grid.showAggregateValues:
+                    this.features.columnAggregate.setState(value);
+                    return;
                 default:
                     throw Error(
                         `changeProperty - Property '${propertyName}' can't be changed.`


### PR DESCRIPTION
This PR created a new input parameter for the Grid. The ShowAggregateValue parameter will add a footer on the grid where the aggregate values of a column will be displayed.

### What was done
* Created a new Feature called Column Aggregate.
* Created new property called showAggregateValue.

### Test Steps
1. Toggle on the ShowAggregateValue button.
Expected: a footer row should be added to the grid.
2. Press Set Price Aggregate button.
Expected: The column price's footer should have a value displayed in bold text. The value is the sum of all price cells.
3. Toggle off the ShowAggregateValue button.
Expected: The footer row should be removed from the grid.
4. Toggle on the ShowAggregateValue button.
Expected:  a footer row should be added on the grid and it should have value on the price column

