### PR TITLE
ROU-3088 - Fixed isChecked validation

### DIFF
--- a/code/src/WijmoProvider/Features/Selection.ts
+++ b/code/src/WijmoProvider/Features/Selection.ts
@@ -324,7 +324,7 @@ namespace WijmoProvider.Feature {
                     this._grid.provider.itemsSource.sourceCollection.filter(
                         (item) =>
                             item?.__osRowMetadata?.get(this._internalLabel)
-                                .isChecked === true
+                                ?.isChecked === true
                     );
 
                 const allCheckedRowsArr = allCheckedRows.map(


### PR DESCRIPTION
This PR is for fixing the getCheckedRowsData method when using GetCheckedRowsData + MarkChangesAsSaved + Pagination, more than one time. 

### What was happening
* An error was triggered: Cannot read properties of undefined (reading 'isChecked').

### What was done
* Added an ?isChecked validation

### Test Steps
1. Select a row and edit it.
2. Click Save
3. Select another row, edit it, and save again.
4. It should successfully save, without errors


### Screenshots
https://i.imgur.com/mr6Dx9I.gif


### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

