### PR TITLE
ROU-3072: Creating SetUnsortState api method

### DIFF
--- a/code/src/GridAPI/Sort.ts
+++ b/code/src/GridAPI/Sort.ts
@@ -91,4 +91,50 @@ namespace GridAPI.Sort {
 
         return JSON.stringify(responseObj);
     }
+    /**
+     * Function that defines whether or not Grid will have Unsort State
+     *
+     * @export
+     * @param {string} gridID ID of the Grid that is to be to check from results.
+     * @param {boolean} hasUnsortState Set to True to add a third state to columns sorting that unsorts the column.
+     * @return {*}  {string} Return Message containing the resulting code from sorting columns and the error message in case of failure
+     */
+    export function SetUnsortState(
+        gridID: string,
+        hasUnsortState: boolean
+    ): string {
+        PerformanceAPI.SetMark('Sort.SetUnsortState');
+
+        const responseObj = {
+            isSuccess: true,
+            message: OSFramework.Enum.ErrorMessages.SuccessMessage,
+            code: OSFramework.Enum.ErrorCodes.GRID_SUCCESS
+        };
+
+        if (!OSFramework.Helper.IsGridReady(gridID)) {
+            responseObj.isSuccess = false;
+            responseObj.message = OSFramework.Enum.ErrorMessages.Grid_NotFound;
+            responseObj.code = OSFramework.Enum.ErrorCodes.CFG_GridNotFound;
+            return JSON.stringify(responseObj);
+        }
+        try {
+            GridManager.GetGridById(gridID).features.sort.setUnsortState(
+                hasUnsortState
+            );
+        } catch (error) {
+            responseObj.isSuccess = false;
+            responseObj.message = error.message;
+            responseObj.code =
+                OSFramework.Enum.ErrorCodes.API_FailedSetUnsortState;
+        }
+
+        PerformanceAPI.SetMark('Sort.SetUnsortState-end');
+        PerformanceAPI.GetMeasure(
+            '@datagrid-Sort.SetUnsortState',
+            'Sort.SetUnsortState',
+            'Sort.SetUnsortState-end'
+        );
+
+        return JSON.stringify(responseObj);
+    }
 }

--- a/code/src/OSFramework/Enum/ErrorCodes.ts
+++ b/code/src/OSFramework/Enum/ErrorCodes.ts
@@ -26,6 +26,7 @@ namespace OSFramework.Enum {
         // SORT
         API_FailedClearSort = 'GRID-API-04001',
         API_FailedColumnSort = 'GRID-API-04002',
+        API_FailedSetUnsortState = 'GRID-API-04003',
         // SELECTION
         API_FailedGetAllSelections = 'GRID-API-05001',
         API_FailedGetAllSelectionsData = 'GRID-API-05002',

--- a/code/src/OSFramework/Feature/IColumnSort.ts
+++ b/code/src/OSFramework/Feature/IColumnSort.ts
@@ -7,6 +7,7 @@ namespace OSFramework.Feature {
         isGridSorted: boolean;
         clear(): void;
         isColumnSorted(columnID: string): boolean;
+        setUnsortState(state: boolean): void;
         sortColumn(columnID: string, ascending: OSStructure.Sorting): void;
     }
 }

--- a/code/src/WijmoProvider/Features/ColumnSort.ts
+++ b/code/src/WijmoProvider/Features/ColumnSort.ts
@@ -33,6 +33,7 @@ namespace WijmoProvider.Feature {
     {
         private _enabled: boolean;
         private _grid: Grid.IGridWijmo;
+        private _hasUnsortState = true;
 
         constructor(grid: Grid.IGridWijmo, enabled: boolean) {
             this._grid = grid;
@@ -113,34 +114,38 @@ namespace WijmoProvider.Feature {
             const index = col.currentSortIndex;
             const sd = s.itemsSource.sortDescriptions[index];
 
-            s.itemsSource.deferUpdate(() => {
-                //Remove on the third click (or when its sort on desc mode)
-                if (sd && !sd.ascending) {
-                    //Add current state before remove it
-                    this._grid.features.undoStack.startAction(
-                        new ColumnSortAction(this._grid.provider)
-                    );
+            if (this._hasUnsortState) {
+                s.itemsSource.deferUpdate(() => {
+                    //Remove on the third click (or when its sort on desc mode)
+                    if (sd && !sd.ascending) {
+                        //Add current state before remove it
+                        this._grid.features.undoStack.startAction(
+                            new ColumnSortAction(this._grid.provider)
+                        );
 
-                    //Remove on the third click
-                    s.itemsSource.sortDescriptions.splice(index, 1);
+                        //Remove on the third click
+                        s.itemsSource.sortDescriptions.splice(index, 1);
 
-                    //Cancel the default behavior
-                    e.cancel = true;
+                        //Cancel the default behavior
+                        e.cancel = true;
 
-                    this._grid.gridEvents.trigger(
-                        OSFramework.Event.Grid.GridEventType.OnSortChange,
-                        this._grid,
-                        this._makeActiveSort(s.itemsSource.sortDescriptions)
-                    );
-                }
+                        this._grid.gridEvents.trigger(
+                            OSFramework.Event.Grid.GridEventType.OnSortChange,
+                            this._grid,
+                            this._makeActiveSort(s.itemsSource.sortDescriptions)
+                        );
+                    }
 
-                //Clean all others if shift isn't pressed
-                if (!e.data.shiftKey) {
-                    s.itemsSource.sortDescriptions
-                        .filter((x) => x !== sd)
-                        .map((x) => s.itemsSource.sortDescriptions.remove(x));
-                }
-            });
+                    //Clean all others if shift isn't pressed
+                    if (!e.data.shiftKey) {
+                        s.itemsSource.sortDescriptions
+                            .filter((x) => x !== sd)
+                            .map((x) =>
+                                s.itemsSource.sortDescriptions.remove(x)
+                            );
+                    }
+                });
+            }
 
             if (e.cancel) {
                 // Save the final state - When we cancel a sorting event, we need to force undoStack closing
@@ -198,6 +203,10 @@ namespace WijmoProvider.Feature {
                 ? wijmo.grid.AllowSorting.MultiColumn
                 : wijmo.grid.AllowSorting.None;
             this._enabled = value;
+        }
+
+        public setUnsortState(state: boolean): void {
+            this._hasUnsortState = state;
         }
 
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This PR creates the SetUnsortState method. This method will allow developers to remove the original default unsort state on our Grid.

### Test Steps
1. Toggle off SetUnsortState button.
2. Sort price column three times.
Expected: A success message shall appear and there should be no unsort state on the column



