### PR TITLE
ROU-2855: Adding background color to aggregate column footer

### DIFF
--- a/code/styles/Grid.css
+++ b/code/styles/Grid.css
@@ -414,6 +414,10 @@
     background: var(--datagrid-column-picker-item-hover-background);
 }
 
+.wj-bottomleft .wj-cell.wj-header, .wj-colfooters .wj-cell.wj-header{
+    background-color: var(--color-neutral-3);
+}
+
 /**** DATAGRID STYLE CLASSES ****/
 
 * {


### PR DESCRIPTION
This PR adds background color to the aggregate column footer


### What was happening
* When we set showAggregateValues to true, the column was hard to differentiate from others
![image](https://user-images.githubusercontent.com/3113318/153405676-61976b93-91c7-435e-90ea-be4f4b36a50e.png)

### What was done
* Added a background color to it.
![image](https://user-images.githubusercontent.com/3113318/153406269-c96a74e4-a966-4e84-b926-a7db0184836b.png)

