### PR TITLE
ROU-3103 -  Created new ExtDate class and changed ToOSFormat

### DIFF
--- a/code/src/OSFramework/OSStructure/ExtendedDate.ts
+++ b/code/src/OSFramework/OSStructure/ExtendedDate.ts
@@ -1,0 +1,7 @@
+// Auxiliary class that helps us define which type of date comes from the platform data (date or datetime)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.OSStructure {
+    export class ExtendedDate extends Date {
+        public isDate: boolean;
+    }
+}


### PR DESCRIPTION
This PR is for fixing the format method, which was not working correctly for date columns, as original conversion solution did not retrieve the correct binding for the column.

### What was done
* Created new ExtendedDate class, that extends the Date and adds an isDate property.
* Changed ToOSFormat method, so that it can accurately cycle the structure from the platform and format the date fields

### Test Steps
1. Open the screen
2. Click 'Json deserialize' button
3. The FeedbackMessage should return a date correctly format (no null date)

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

