### PR TITLE
ROU-3050: Adding extra validation on getRowData method

### DIFF
--- a/code/src/OSFramework/Helper/Flattener.ts
+++ b/code/src/OSFramework/Helper/Flattener.ts
@@ -2,24 +2,26 @@
 namespace OSFramework.Helper {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export function Flatten(obj: JSON): any {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let keys: any;
-        // eslint-disable-next-line prefer-const
-        let transformedObj = {};
-        Object.keys(obj).forEach((lineCol) => {
-            keys = Object.keys(obj[lineCol]);
+        if (obj !== undefined) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            let keys: any;
+            // eslint-disable-next-line prefer-const
+            let transformedObj = {};
+            Object.keys(obj).forEach((lineCol) => {
+                keys = Object.keys(obj[lineCol]);
 
-            if (typeof obj[lineCol] === 'string' || keys.length === 0) {
-                transformedObj[lineCol] = obj[lineCol];
-            } else {
-                keys.forEach((prop) => {
-                    let proname = prop;
-                    if (transformedObj.hasOwnProperty(prop))
-                        proname = lineCol + '.' + prop;
-                    transformedObj[proname] = obj[lineCol][prop];
-                });
-            }
-        });
-        return transformedObj;
+                if (typeof obj[lineCol] === 'string' || keys.length === 0) {
+                    transformedObj[lineCol] = obj[lineCol];
+                } else {
+                    keys.forEach((prop) => {
+                        let proname = prop;
+                        if (transformedObj.hasOwnProperty(prop))
+                            proname = lineCol + '.' + prop;
+                        transformedObj[proname] = obj[lineCol][prop];
+                    });
+                }
+            });
+            return transformedObj;
+        }
     }
 }

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -379,7 +379,7 @@ namespace WijmoProvider.Feature {
         public getRowData(rowNumber: number): any {
             const row = this._grid.isSingleEntity
                 ? OSFramework.Helper.Flatten(
-                      this._grid.provider.rows[rowNumber].dataItem
+                      this._grid.provider.rows[rowNumber]?.dataItem
                   )
                 : this._grid.provider.rows[rowNumber].dataItem;
 


### PR DESCRIPTION
This PR adds an extra validation on getRowData method

### What was happening
* Whenever we passed an invalid row number to the getRowData method, Cannot read properties of undefined was thrown because we didn't validate whether or not the row existed.



