### PR TITLE
ROU-3130: Fixing GetColumnById

### DIFF
--- a/code/src/GridAPI/ColumnManager.ts
+++ b/code/src/GridAPI/ColumnManager.ts
@@ -105,7 +105,8 @@ namespace GridAPI.ColumnManager {
     export function GetColumnById(
         columnID: string
     ): OSFramework.Column.IColumn {
-        return columnArr.find((p) => p && p.equalsToID(columnID));
+        // we want to return the last column in our array that matches our predicate
+        return _.findLast(columnArr, (p) => p && p.equalsToID(columnID));
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug where GetColumnById wasn't working whenever Grid was initialized from a screen transition.

### What was happening
* After screen transition, GridInitialize is called before Column Destroy, which means that the first column was still present on our columns array. Since we were using Array.find method, only the first element was returned. In this case, this meant that the returned element was the column from the first screen, which was not yet destroyed.

### What was done
* Changed the way we found our columns. Instead of looking for the first element, we now look for the last element.

### Test Steps
1. Open sample.
2. Check if the column name is "I am grid 1".
3. Press GridRedirected link.

Expected: The column's name should still be "I am grid 1".

1. Open sample.
2. Check if the column name is "I am grid 1".
3. Press GridRedirected2 link.
Expected: The column's name should be "I am grid 2".
4. Press GridRedirect link
Expected: The column's name should be "I am grid 1".

