### PR TITLE
ROU-2899: Changing GetGridByID

### DIFF
--- a/code/src/GridAPI/GridManager.ts
+++ b/code/src/GridAPI/GridManager.ts
@@ -96,13 +96,11 @@ namespace GridAPI.GridManager {
         if (gridMap.has(gridID)) {
             grid = gridMap.get(gridID);
         } else {
-            //Search for WidgetId
-            for (const p of gridMap.values()) {
-                if (p.equalsToID(gridID)) {
-                    grid = p;
-                    break;
-                }
-            }
+            //Search for last inserted grid containing widgetId
+            grid = _.findLast(
+                Array.from(gridMap.values()),
+                (p) => p && p.equalsToID(gridID)
+            );
         }
 
         if (grid === undefined && raiseError) {


### PR DESCRIPTION
This PR fixes a bug where FilterChange event wasn't working whenever Grid was initialized from a screen transition.

# What was happening
After screen transition, GridInitialize is called before Grid Destroy, which means that the first grid was still present on our Grid map. Since we were using for-of loop, we stopped the iteration when the first element with widgetID was found. In this case, this meant that the returned element was the grid from the first screen, which was not yet destroyed.

# What was done
Changed the way we find our grids. Instead of looking for the first element, we now look for the last element.

# Test Steps
1. Open sample.
2. Filter any column by any value
3. Check if filter data is shown on Event table.
4. Press Use columns button
5. Filter any column by any value
6. Check if filter data is shown on Event table.
