### PR TITLE
ROU-3147: Emptying invalidRows array on clear

### DIFF
--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -354,6 +354,7 @@ namespace WijmoProvider.Feature {
         /** Clears all the validation mark metadata associated to the rows */
         public clear(): void {
             this._metadata.clearProperty(this._internalLabel);
+            this._invalidRows = [];
             this._grid.provider.invalidate(); //Mark to be refreshed
         }
 


### PR DESCRIPTION
This PR fixes an issue where MarkChangesAsSaved was not removing invalid rows from GetChangedLines.

### What was happening
* Whenever a row has invalid content, and MarkChangesAsSaves and GetChangedLines were called, the invalidRow was still there, even with the use of MarkChangesAsSaved with ForceCleanInvalid param set to true.

### What was done
* Emptied invalidRows array whenever ValidationMark clear is called.

### Test Steps
1. Press SetCellInvalid button. The cell should become invalid.
2. Press GetChangedLines button. The Invalid lines should contain the row containing the invalid cell.
3. Press MarkChangesAsSaved button. The cell should become valid.
4. Press GetChangedLines button. The Invalid lines should be empty

