### PR TITLE
Getting the cell data for the correct type of column

### DIFF
--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -39,7 +39,12 @@ namespace WijmoProvider.Feature {
             e: wijmo.grid.CellRangeEventArgs
         ): void {
             const binding = s.getColumn(e.col).binding;
-            const newValue = s.getCellData(e.row, e.col, false);
+            const newValue = s.getCellData(
+                e.row,
+                e.col,
+                this._grid.getColumn(binding).columnType ===
+                    OSFramework.Enum.ColumnType.Dropdown
+            );
             // The old value can be captured on the dirtyMark feature as it is the one responsible for saving the original values
             const oldValue = this._grid.features.dirtyMark.getOldValue(
                 e.row,
@@ -628,7 +633,7 @@ namespace WijmoProvider.Feature {
             const currValue = this._grid.provider.getCellData(
                 rowNumber,
                 column.provider.index,
-                false
+                column.columnType === OSFramework.Enum.ColumnType.Dropdown
             );
             // Triggers the events of OnCellValueChange associated to a specific column in OS
             this._triggerEventsFromColumn(
@@ -656,7 +661,8 @@ namespace WijmoProvider.Feature {
                         const currValue = this._grid.provider.getCellData(
                             rowNumber,
                             column.provider.index,
-                            false
+                            column.columnType ===
+                                OSFramework.Enum.ColumnType.Dropdown
                         );
                         // Triggers the events of OnCellValueChange associated to a specific column in OS
                         this._triggerEventsFromColumn(


### PR DESCRIPTION
This PR is to fix an issue when using parent binding and dropdowns,  where if we opened the dropdown without doing any changes, the associated column will also change and it shouldn’t since nothing changed.

### What was happening
* when using parent binding and dropdowns,  where if we opened the dropdown without doing any changes, the associated column will also change and it shouldn’t since nothing changed:
![ParentBindingNoChangesIssue](https://user-images.githubusercontent.com/29493222/157108331-a756098e-adf7-494e-82ea-79f54e24b310.gif)


### Test Steps
Validate parent binding when no changes on the dropdown options:
1. Open Page
2. In the 'Employee department' column, open the first dropdown and click on the same option.

Expected: 
- The value on the 'Employee' remains the same "

Validate parent binding with changes on the dropdown options:
1. Open Page
2. In the 'Employee department' column, open the first dropdown and click on a different option.

Expected: 
- The value on the 'Employee' is cleared"


### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint


