### PR TITLE
ROU-3217: OnCellValueChangeEvent of Data Grid not fired when two columns have the same binding

### DIFF
--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -3,8 +3,7 @@ namespace WijmoProvider.Feature {
     export class DirtyMark
         implements
             OSFramework.Feature.IDirtyMark,
-            OSFramework.Interface.IBuilder
-    {
+            OSFramework.Interface.IBuilder {
         private _grid: Grid.IGridWijmo;
         private readonly _internalLabel = '__dirtyMarkFeature';
         private _metadata: OSFramework.Interface.IRowMetadata;

--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -3,7 +3,8 @@ namespace WijmoProvider.Feature {
     export class DirtyMark
         implements
             OSFramework.Feature.IDirtyMark,
-            OSFramework.Interface.IBuilder {
+            OSFramework.Interface.IBuilder
+    {
         private _grid: Grid.IGridWijmo;
         private readonly _internalLabel = '__dirtyMarkFeature';
         private _metadata: OSFramework.Interface.IRowMetadata;

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -654,7 +654,7 @@ namespace WijmoProvider.Feature {
             // Triggers the events of OnCellValueChange associated to a specific column in OS
             this._triggerEventsFromColumn(
                 rowNumber,
-                column.provider.uniqueId,
+                column.uniqueId,
                 currValue,
                 currValue
             );
@@ -683,7 +683,7 @@ namespace WijmoProvider.Feature {
                         // Triggers the events of OnCellValueChange associated to a specific column in OS
                         this._triggerEventsFromColumn(
                             rowNumber,
-                            column.provider.uniqueId,
+                            column.uniqueId,
                             currValue,
                             currValue
                         );

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -3,7 +3,8 @@ namespace WijmoProvider.Feature {
     export class ValidationMark
         implements
             OSFramework.Feature.IValidationMark,
-            OSFramework.Interface.IBuilder {
+            OSFramework.Interface.IBuilder
+    {
         private _grid: Grid.IGridWijmo;
         /** Internal label for the validation marks */
         private readonly _internalLabel = '__validationMarkFeature';
@@ -171,8 +172,9 @@ namespace WijmoProvider.Feature {
                 action.dataItem !== undefined &&
                 typeof action._oldState !== 'object'
             ) {
-                const binding = this._grid.provider.getColumn(action.col)
-                    .binding;
+                const binding = this._grid.provider.getColumn(
+                    action.col
+                ).binding;
 
                 const OSColumn = this._grid
                     .getColumns()
@@ -219,9 +221,8 @@ namespace WijmoProvider.Feature {
          */
         private _setRowStatusByKey(rowKey: string, isValid: boolean): void {
             const rowIndex = this._metadata.getRowIndexByKey(rowKey);
-            const dataItem = this._grid.provider.itemsSource.sourceCollection[
-                rowIndex
-            ];
+            const dataItem =
+                this._grid.provider.itemsSource.sourceCollection[rowIndex];
 
             if (this._invalidRows.indexOf(dataItem) === -1) {
                 if (isValid === false) {
@@ -309,8 +310,9 @@ namespace WijmoProvider.Feature {
                 action.dataItem !== undefined &&
                 typeof action._oldState !== 'object'
             ) {
-                const binding = this._grid.provider.getColumn(action.col)
-                    .binding;
+                const binding = this._grid.provider.getColumn(
+                    action.col
+                ).binding;
                 const oldValue = this._grid.features.dirtyMark.getOldValue(
                     action.row,
                     binding
@@ -565,8 +567,8 @@ namespace WijmoProvider.Feature {
             isValid: boolean,
             errorMessage: string
         ): void {
-            const column = GridAPI.ColumnManager.GetColumnById(columnWidgetID)
-                .provider;
+            const column =
+                GridAPI.ColumnManager.GetColumnById(columnWidgetID).provider;
 
             // Sets the validation map by matching the binding of the columns with the boolean that indicates whether theres is an invalid cell in the row or not.
             this.getMetadataByRowNumber(rowNumber).validation.set(
@@ -607,8 +609,8 @@ namespace WijmoProvider.Feature {
             isValid: boolean,
             errorMessage: string
         ): void {
-            const column = GridAPI.ColumnManager.GetColumnById(columnWidgetID)
-                .provider;
+            const column =
+                GridAPI.ColumnManager.GetColumnById(columnWidgetID).provider;
 
             // Sets the validation map by matching the binding of the columns with the boolean that indicates whether theres is an invalid cell in the row or not.
             this.getMetadataByRowKey(rowKey).validation.set(
@@ -696,9 +698,8 @@ namespace WijmoProvider.Feature {
                 };
             } catch (error) {
                 return {
-                    code:
-                        OSFramework.Enum.ErrorCodes
-                            .API_FailedApplyRowValidation,
+                    code: OSFramework.Enum.ErrorCodes
+                        .API_FailedApplyRowValidation,
                     message: error.message,
                     isSuccess: false
                 };

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -3,7 +3,8 @@ namespace WijmoProvider.Feature {
     export class ValidationMark
         implements
             OSFramework.Feature.IValidationMark,
-            OSFramework.Interface.IBuilder {
+            OSFramework.Interface.IBuilder
+    {
         private _grid: Grid.IGridWijmo;
         /** Internal label for the validation marks */
         private readonly _internalLabel = '__validationMarkFeature';
@@ -171,8 +172,9 @@ namespace WijmoProvider.Feature {
                 action.dataItem !== undefined &&
                 typeof action._oldState !== 'object'
             ) {
-                const binding = this._grid.provider.getColumn(action.col)
-                    .binding;
+                const binding = this._grid.provider.getColumn(
+                    action.col
+                ).binding;
                 const oldValue = this._grid.features.dirtyMark.getOldValue(
                     action.row,
                     binding
@@ -215,9 +217,8 @@ namespace WijmoProvider.Feature {
          */
         private _setRowStatusByKey(rowKey: string, isValid: boolean): void {
             const rowIndex = this._metadata.getRowIndexByKey(rowKey);
-            const dataItem = this._grid.provider.itemsSource.sourceCollection[
-                rowIndex
-            ];
+            const dataItem =
+                this._grid.provider.itemsSource.sourceCollection[rowIndex];
 
             if (this._invalidRows.indexOf(dataItem) === -1) {
                 if (isValid === false) {
@@ -305,8 +306,9 @@ namespace WijmoProvider.Feature {
                 action.dataItem !== undefined &&
                 typeof action._oldState !== 'object'
             ) {
-                const binding = this._grid.provider.getColumn(action.col)
-                    .binding;
+                const binding = this._grid.provider.getColumn(
+                    action.col
+                ).binding;
                 const oldValue = this._grid.features.dirtyMark.getOldValue(
                     action.row,
                     binding
@@ -558,8 +560,8 @@ namespace WijmoProvider.Feature {
             isValid: boolean,
             errorMessage: string
         ): void {
-            const column = GridAPI.ColumnManager.GetColumnById(columnWidgetID)
-                .provider;
+            const column =
+                GridAPI.ColumnManager.GetColumnById(columnWidgetID).provider;
 
             // Sets the validation map by matching the binding of the columns with the boolean that indicates whether theres is an invalid cell in the row or not.
             this.getMetadataByRowNumber(rowNumber).validation.set(
@@ -600,8 +602,8 @@ namespace WijmoProvider.Feature {
             isValid: boolean,
             errorMessage: string
         ): void {
-            const column = GridAPI.ColumnManager.GetColumnById(columnWidgetID)
-                .provider;
+            const column =
+                GridAPI.ColumnManager.GetColumnById(columnWidgetID).provider;
 
             // Sets the validation map by matching the binding of the columns with the boolean that indicates whether theres is an invalid cell in the row or not.
             this.getMetadataByRowKey(rowKey).validation.set(
@@ -689,9 +691,8 @@ namespace WijmoProvider.Feature {
                 };
             } catch (error) {
                 return {
-                    code:
-                        OSFramework.Enum.ErrorCodes
-                            .API_FailedApplyRowValidation,
+                    code: OSFramework.Enum.ErrorCodes
+                        .API_FailedApplyRowValidation,
                     message: error.message,
                     isSuccess: false
                 };

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -253,9 +253,7 @@ namespace WijmoProvider.Feature {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             newValue: any
         ) {
-            const column = this._grid
-                .getColumns()
-                .find((item) => item.provider.uniqueId === columnUniqueID);
+            const column = this._grid.getColumn(columnUniqueID);
 
             if (column !== undefined) {
                 if (column.config.isMandatory) {

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -250,7 +250,7 @@ namespace WijmoProvider.Feature {
         ) {
             const column = this._grid
                 .getColumns()
-                .find((column) => column.provider.index === columnIndex);
+                .find((item) => item.provider.index === columnIndex);
 
             if (column !== undefined) {
                 if (column.config.isMandatory) {

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -3,8 +3,7 @@ namespace WijmoProvider.Feature {
     export class ValidationMark
         implements
             OSFramework.Feature.IValidationMark,
-            OSFramework.Interface.IBuilder
-    {
+            OSFramework.Interface.IBuilder {
         private _grid: Grid.IGridWijmo;
         /** Internal label for the validation marks */
         private readonly _internalLabel = '__validationMarkFeature';
@@ -55,7 +54,7 @@ namespace WijmoProvider.Feature {
             );
             this._triggerEventsFromColumn(
                 e.row,
-                column.index,
+                OSColumn.uniqueId,
                 oldValue,
                 newValue
             );
@@ -172,16 +171,19 @@ namespace WijmoProvider.Feature {
                 action.dataItem !== undefined &&
                 typeof action._oldState !== 'object'
             ) {
-                const binding = this._grid.provider.getColumn(
-                    action.col
-                ).binding;
+                const binding = this._grid.provider.getColumn(action.col)
+                    .binding;
+
+                const OSColumn = this._grid
+                    .getColumns()
+                    .find((item) => item.provider.index === action.col);
                 const oldValue = this._grid.features.dirtyMark.getOldValue(
                     action.row,
                     binding
                 );
                 this._triggerEventsFromColumn(
                     action.row,
-                    action.col,
+                    OSColumn.uniqueId,
                     oldValue,
                     action._newState
                 );
@@ -217,8 +219,9 @@ namespace WijmoProvider.Feature {
          */
         private _setRowStatusByKey(rowKey: string, isValid: boolean): void {
             const rowIndex = this._metadata.getRowIndexByKey(rowKey);
-            const dataItem =
-                this._grid.provider.itemsSource.sourceCollection[rowIndex];
+            const dataItem = this._grid.provider.itemsSource.sourceCollection[
+                rowIndex
+            ];
 
             if (this._invalidRows.indexOf(dataItem) === -1) {
                 if (isValid === false) {
@@ -237,13 +240,13 @@ namespace WijmoProvider.Feature {
         /**
          * Triggers the events of OnCellValueChange associated to a specific column in OS
          * @param rowNumber Number of the row to trigger the events
-         * @param columnIndex Index of the Column that contains the associated events
+         * @param columnUniqueID Id of the Column that contains the associated events
          * @param oldValue Value of the cell before its value has changed (Old)
          * @param newValue Value of the cell after its value has changed (New)
          */
         private _triggerEventsFromColumn(
             rowNumber: number,
-            columnIndex: number,
+            columnUniqueID: string,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             oldValue: any,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -251,7 +254,7 @@ namespace WijmoProvider.Feature {
         ) {
             const column = this._grid
                 .getColumns()
-                .find((item) => item.provider.index === columnIndex);
+                .find((item) => item.provider.uniqueId === columnUniqueID);
 
             if (column !== undefined) {
                 if (column.config.isMandatory) {
@@ -306,16 +309,18 @@ namespace WijmoProvider.Feature {
                 action.dataItem !== undefined &&
                 typeof action._oldState !== 'object'
             ) {
-                const binding = this._grid.provider.getColumn(
-                    action.col
-                ).binding;
+                const binding = this._grid.provider.getColumn(action.col)
+                    .binding;
                 const oldValue = this._grid.features.dirtyMark.getOldValue(
                     action.row,
                     binding
                 );
+                const OSColumn = this._grid
+                    .getColumns()
+                    .find((item) => item.provider.index === action.col);
                 this._triggerEventsFromColumn(
                     action.row,
-                    action.col,
+                    OSColumn.uniqueId,
                     oldValue,
                     action._oldState
                 );
@@ -560,8 +565,8 @@ namespace WijmoProvider.Feature {
             isValid: boolean,
             errorMessage: string
         ): void {
-            const column =
-                GridAPI.ColumnManager.GetColumnById(columnWidgetID).provider;
+            const column = GridAPI.ColumnManager.GetColumnById(columnWidgetID)
+                .provider;
 
             // Sets the validation map by matching the binding of the columns with the boolean that indicates whether theres is an invalid cell in the row or not.
             this.getMetadataByRowNumber(rowNumber).validation.set(
@@ -602,8 +607,8 @@ namespace WijmoProvider.Feature {
             isValid: boolean,
             errorMessage: string
         ): void {
-            const column =
-                GridAPI.ColumnManager.GetColumnById(columnWidgetID).provider;
+            const column = GridAPI.ColumnManager.GetColumnById(columnWidgetID)
+                .provider;
 
             // Sets the validation map by matching the binding of the columns with the boolean that indicates whether theres is an invalid cell in the row or not.
             this.getMetadataByRowKey(rowKey).validation.set(
@@ -649,7 +654,7 @@ namespace WijmoProvider.Feature {
             // Triggers the events of OnCellValueChange associated to a specific column in OS
             this._triggerEventsFromColumn(
                 rowNumber,
-                column.provider.binding,
+                column.provider.uniqueId,
                 currValue,
                 currValue
             );
@@ -678,7 +683,7 @@ namespace WijmoProvider.Feature {
                         // Triggers the events of OnCellValueChange associated to a specific column in OS
                         this._triggerEventsFromColumn(
                             rowNumber,
-                            column.provider.binding,
+                            column.provider.uniqueId,
                             currValue,
                             currValue
                         );
@@ -691,8 +696,9 @@ namespace WijmoProvider.Feature {
                 };
             } catch (error) {
                 return {
-                    code: OSFramework.Enum.ErrorCodes
-                        .API_FailedApplyRowValidation,
+                    code:
+                        OSFramework.Enum.ErrorCodes
+                            .API_FailedApplyRowValidation,
                     message: error.message,
                     isSuccess: false
                 };


### PR DESCRIPTION
This PR is for OnCellValueChangeEvent of Data Grid to be fired even when two columns have the same binding

### What was happening
* The OnCellValueChangeEvent was not being fired when I have two columns in the data grid binding to the same attribute in the database. I set a client action as the handler to the event on one of the columns. When I changed the value of the cell of that column, the client action does not get executed. However, when I remove the other column with the same binding, the event is fired and handled by the client action as it should be.

### What was done
* Change _triggerEventsFormColumn to use column index instead of column binding as input parameter

### Test Steps
1. Add a DataGrid to the screen
2. Config multiple columns with the same binding; 
3. Add custom events to some of the columns on OnCellValueChange;
4. Check if the event feedback is the expected

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

