### PR TITLE
ROU-2898: Fixing multisort error on group panel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,8 @@ stages:
       - job: Build
         displayName: 'Build Job'
         timeoutInMinutes: 8
+        pool:
+          vmImage: 'windows-latest'
         steps:
           #Install dependencies
           - task: Npm@1
@@ -68,6 +70,8 @@ stages:
       - job: Deploy
         displayName: 'Deploy Job'
         timeoutInMinutes: 20
+        pool:
+          vmImage: 'windows-latest'
         steps:
           #Download artifact
           - task: DownloadBuildArtifacts@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,6 @@ stages:
       - job: Build
         displayName: 'Build Job'
         timeoutInMinutes: 8
-        pool:
-          vmImage: 'windows-latest'
         steps:
           #Install dependencies
           - task: Npm@1
@@ -70,8 +68,6 @@ stages:
       - job: Deploy
         displayName: 'Deploy Job'
         timeoutInMinutes: 20
-        pool:
-          vmImage: 'windows-latest'
         steps:
           #Download artifact
           - task: DownloadBuildArtifacts@0

--- a/code/src/WijmoProvider/Features/ColumnSort.ts
+++ b/code/src/WijmoProvider/Features/ColumnSort.ts
@@ -85,6 +85,16 @@ namespace WijmoProvider.Feature {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             e: wijmo.grid.CellRangeEventArgs
         ) {
+            const col = s.getColumn(e.col);
+            const index = col.currentSortIndex;
+            const sd = s.itemsSource.sortDescriptions[index];
+            //Clean all others if shift isn't pressed
+            if (!e.data.shiftKey) {
+                s.itemsSource.sortDescriptions
+                    .filter((x) => x !== sd)
+                    .map((x) => s.itemsSource.sortDescriptions.remove(x));
+            }
+
             if (
                 this._grid.gridEvents.hasHandlers(
                     OSFramework.Event.Grid.GridEventType.OnSortChange
@@ -134,15 +144,6 @@ namespace WijmoProvider.Feature {
                             this._grid,
                             this._makeActiveSort(s.itemsSource.sortDescriptions)
                         );
-                    }
-
-                    //Clean all others if shift isn't pressed
-                    if (!e.data.shiftKey) {
-                        s.itemsSource.sortDescriptions
-                            .filter((x) => x !== sd)
-                            .map((x) =>
-                                s.itemsSource.sortDescriptions.remove(x)
-                            );
                     }
                 });
             }

--- a/jobs/azure-pipelines-reactive.yml
+++ b/jobs/azure-pipelines-reactive.yml
@@ -43,6 +43,10 @@ parameters:
   type: string
 - name: sourceBranch
   type: string
+- name: instances
+  displayName: Max driver instances
+  type: number
+  default: 2
 
 stages: 
 - stage: Tests
@@ -53,8 +57,6 @@ stages:
   - job: Tests
     displayName: 'Tests Job'
     timeoutInMinutes: 120
-    pool:
-      vmImage: 'windows-latest'
     steps:
     #Checkout repositories
     - checkout: self

--- a/jobs/azure-pipelines-reactive.yml
+++ b/jobs/azure-pipelines-reactive.yml
@@ -57,6 +57,8 @@ stages:
   - job: Tests
     displayName: 'Tests Job'
     timeoutInMinutes: 120
+    pool:
+          vmImage: 'windows-latest'
     steps:
     #Checkout repositories
     - checkout: self

--- a/jobs/azure-pipelines-template.yml
+++ b/jobs/azure-pipelines-template.yml
@@ -17,7 +17,7 @@ steps:
   #Set Node version
   - task: NodeTool@0
     inputs:
-      versionSpec: '^10 || ^12 || ^14'
+      versionSpec: ^16
 
   #Format branch name
   - task: PowerShell@2
@@ -54,7 +54,7 @@ steps:
     displayName: 'Install dependencies using yarn'
     inputs:
       workingDirectory: './datagrid-reactive-tests/'
-      script: 'yarn install'
+      script: 'yarn'
     continueOnError: false
 
   #Retrieve test features
@@ -71,7 +71,7 @@ steps:
     inputs:
       workingDir: './datagrid-reactive-tests/'
       command: 'custom'
-      customCommand: 'run saucelabs -- --user=$(SAUCE_LABS_USER) --key=$(SAUCE_LABS_KEY) --module=$(branch) "--browsers=${{ parameters.browser }}" --headless=false --environment=${{ parameters.environment }} --grid=${{ parameters.grid }}  --cucumberOpts.tagExpression=@${{ parameters.grid }}'
+      customCommand: 'run saucelabs -- --user=$(SAUCE_LABS_USER) --key=$(SAUCE_LABS_KEY) --module=$(branch) "--browsers=${{ parameters.browser }}" --instances=${{ parameters.instances }} --environment=${{ parameters.environment }} --grid=${{ parameters.grid }}  --cucumberOpts.tagExpression=@${{ parameters.grid }}'
 
   #Run tests on specific features
   - task: Npm@1
@@ -80,7 +80,7 @@ steps:
     inputs:
       workingDir: './datagrid-reactive-tests'
       command: 'custom'
-      customCommand: 'run saucelabs -- --user=$(SAUCE_LABS_USER) --key=$(SAUCE_LABS_KEY) --module=$(branch) "--browsers=${{ parameters.browser }}" --headless=false --environment=${{ parameters.environment }} --grid=${{ parameters.grid }}  "--cucumberOpts.tagExpression=$(features)"'
+      customCommand: 'run saucelabs -- --user=$(SAUCE_LABS_USER) --key=$(SAUCE_LABS_KEY) --module=$(branch) "--browsers=${{ parameters.browser }}" --instances=${{ parameters.instances }} --environment=${{ parameters.environment }} --grid=${{ parameters.grid }}  "--cucumberOpts.tagExpression=$(features)"'
 
   #Only run task if skip is not true
   - task: Npm@1

--- a/jobs/azure-pipelines-template.yml
+++ b/jobs/azure-pipelines-template.yml
@@ -12,6 +12,9 @@ parameters:
     type: string
   - name: grid
     type: string
+  - name: instances
+    type: number
+    default: 1  
 
 steps:
   #Set Node version


### PR DESCRIPTION
This PR fixes a bug where multi sort was breaking when used on the group panel. This seemed to happen because whenever we removed the multi sort state on the group panel column, we were removing the sort description from wijmo’s sort array and wijmo’s code breaks because it expects two sort descriptions. So whenever it tries to access the second one, it throws the Cannot read properties of undefined (reading 'ascending'). 


### What was done
* Moved the deletion to the Sorted event and it seemed to work. Will run a regression to see if there is no side effect. 

### Test Steps
1. Drag Product Name into the group panel.
2. Pressing shift sort Product Category
3. Pressing shift sort Product Name
4. Not pressing shift, sort Product name again.

Expected: Product Name should be sorted desc and the sort from Product Category should be cleared.

