### PR TITLE
ROU-3145: Update SetCellData logic

### DIFF
--- a/code/src/GridAPI/Cells.ts
+++ b/code/src/GridAPI/Cells.ts
@@ -68,11 +68,13 @@ namespace GridAPI.Cells {
      * @param {string} gridID ID of the Grid.
      * @param {number} rowIndex Index of the row that contains the cells to be validated.
      * @param {string} columnID ID of the Column block in which the action of validation should be triggered.
+     * @param {boolean} [triggerOnCellValueChange=true] Boolean that represents if we want to trigger the on value change event or not
      */
     export function ValidateCell(
         gridID: string,
         rowIndex: number,
-        columnID: string
+        columnID: string,
+        triggerOnCellValueChange = true
     ): void {
         PerformanceAPI.SetMark('Cells.validateCell');
 
@@ -80,7 +82,8 @@ namespace GridAPI.Cells {
         if (column === undefined) return;
         GridManager.GetGridById(gridID).features.validationMark.validateCell(
             rowIndex,
-            column
+            column,
+            triggerOnCellValueChange
         );
         PerformanceAPI.SetMark('Cells.validateCell-end');
         PerformanceAPI.GetMeasure(
@@ -126,6 +129,7 @@ namespace GridAPI.Cells {
      * @param {string} columnID ID of the Column block in which the cell should be updated.
      * @param {*} value New value to settled on the cell.
      * @param {boolean} [showDirtyMark=true] Boolean that represents if the action should also show a dirty mark.
+     * @param {boolean} [triggerOnCellValueChange=true] Boolean that represents if we want to trigger the on value change event or not
      */
     export function SetCellData(
         gridID: string,
@@ -133,7 +137,8 @@ namespace GridAPI.Cells {
         columnID: string,
         // eslint-disable-next-line
         value: any,
-        showDirtyMark = true
+        showDirtyMark = true,
+        triggerOnCellValueChange = true
     ): string {
         const responseObj = {
             isSuccess: true,
@@ -168,7 +173,11 @@ namespace GridAPI.Cells {
                 );
             }
             grid.features.cellData.setCellData(rowIndex, column, value);
-            grid.features.validationMark.validateCell(rowIndex, column);
+            grid.features.validationMark.validateCell(
+                rowIndex,
+                column,
+                triggerOnCellValueChange
+            );
         } catch (error) {
             responseObj.isSuccess = false;
             responseObj.message = error.message;

--- a/code/src/OSFramework/Feature/IValidationMark.ts
+++ b/code/src/OSFramework/Feature/IValidationMark.ts
@@ -25,7 +25,8 @@ namespace OSFramework.Feature {
         setRowStatus(rowNumber: number, isValid: boolean): void;
         validateCell(
             rowNumber: number,
-            column: OSFramework.Column.IColumn
+            column: OSFramework.Column.IColumn,
+            triggerOnCellValueChange: boolean
         ): void;
         validateRow(rowNumber: number): OSFramework.OSStructure.ReturnMessage;
         // clearByRow(row: number): void;

--- a/code/src/WijmoProvider/Columns/DropdownColumn.ts
+++ b/code/src/WijmoProvider/Columns/DropdownColumn.ts
@@ -49,7 +49,11 @@ namespace WijmoProvider.Column {
                     '',
                     true
                 );
-                this.grid.features.validationMark.validateCell(rowNumber, this);
+                this.grid.features.validationMark.validateCell(
+                    rowNumber,
+                    this,
+                    true
+                );
 
                 const column = this.grid.getColumn(columnID);
 

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -625,9 +625,18 @@ namespace WijmoProvider.Feature {
             this._setRowStatus(rowNumber, isValid);
         }
 
+        /**
+         * Method to validate a cell
+         *
+         * @param {number} rowNumber Number of the row in which the action of validation should be triggered.
+         * @param {OSFramework.Column.IColumn} column Column in which the action of validation should be triggered.
+         * @param {boolean} [triggerOnCellValueChange=true] Boolean that represents if we want to trigger the on value change event or not
+         * @memberof ValidationMark
+         */
         public validateCell(
             rowNumber: number,
-            column: OSFramework.Column.IColumn
+            column: OSFramework.Column.IColumn,
+            triggerOnCellValueChange = true
         ): void {
             // This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
             const currValue = this._grid.provider.getCellData(
@@ -635,13 +644,17 @@ namespace WijmoProvider.Feature {
                 column.provider.index,
                 column.columnType === OSFramework.Enum.ColumnType.Dropdown
             );
-            // Triggers the events of OnCellValueChange associated to a specific column in OS
-            this._triggerEventsFromColumn(
-                rowNumber,
-                column.provider.binding,
-                currValue,
-                currValue
-            );
+
+            //If we decide not to trigger the column events we will skip this step
+            if (triggerOnCellValueChange) {
+                // Triggers the events of OnCellValueChange associated to a specific column in OS
+                this._triggerEventsFromColumn(
+                    rowNumber,
+                    column.provider.binding,
+                    currValue,
+                    currValue
+                );
+            }
         }
 
         /**


### PR DESCRIPTION
This PR is for an improvement on the method SetCellData to have an extra param indicating if the on cell value change will be triggered or not.


### What was done
* Added an optional parameter (default true) to control via API the ability to trigger OnCellValueChange or not when using the SetCellData method

### Test Steps
1. Go to the test screen
2. Open the browser's console
3. Change the value of the first cell of the ProductName column
4. Checked that a loop with an error is displayed
5. Change the value of the first cell of the ProductCategory column
6. Checked that the value of the first cell of the ProductName column is now “New Name“ and that we only have one log on the console saying “Ran SetCellData Custom inside OnCellValueChange!“


### Screenshots
![ROU3145_Test](https://user-images.githubusercontent.com/29493222/161010707-8bd6d7d8-1e25-4c84-93fc-d9eaa84858d9.gif)

Note: that the customer can achieve this by creating a client like this (equal to SetCellData but the last parameter = False): 
![Capture](https://user-images.githubusercontent.com/29493222/161010776-0cdc3252-b3ac-4d35-8772-81a72772bf87.PNG)



### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint
* [X] requires changes in OutSystems 
* [X] requires new sample page in OutSystems

