### PR TITLE
ROU-3297: Fixing issue with arrange Data

### DIFF
--- a/code/extension/DataGridUtils/Source/NET/temp_ardoJSON.cs
+++ b/code/extension/DataGridUtils/Source/NET/temp_ardoJSON.cs
@@ -163,14 +163,14 @@ namespace OutSystems.NssDataGridUtils {
                     }
                     else
                     {
-                        //Add dates from the ArrangeData action should be returned in UTC
-                        dv = dv.ToUniversalTime();
                         if (dv.Hour == 0 && dv.Minute == 0 && dv.Second == 0) // extra milisecond check ?
                         {
                             json.WriteValue(dv.ToString("yyyy-MM-dd"));
                         }
                         else
                         {
+                            //Add dates from the ArrangeData action should be returned in UTC
+                            dv = dv.ToUniversalTime();
                             json.WriteValue(dv.ToString("yyyy-MM-dd'T'HH:mm:ssZ"));
                         }
                     }


### PR DESCRIPTION
This PR fixes an issue where Date columns were being considered DateTime.


### What was done
* Only convert values that don't have 0h 0m 0s. 

### Test Steps
1. Null dates/datetimes should be displayed as blank.
2. Whenever you edit a Date column, a feedback message with the correct date should appear.

