### PR TITLE
ROU-3361: Fixing issue with GetChangedLines

### DIFF
--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -281,8 +281,10 @@ namespace WijmoProvider.Feature {
             const providerGrid = this._grid.provider;
             const topRowIndex = this._getTopRow();
             // The datasource index of the selection's top row. Requires the page index and the page size.
-            const dsTopRowIndex =
+            let dsTopRowIndex =
                 topRowIndex + this._grid.features.pagination.rowStart - 1;
+            // we don't want negative indices.
+            dsTopRowIndex = dsTopRowIndex > 0 ? dsTopRowIndex : 0;
             // Consider the quantity 1 if there is no selection.
             const quantity =
                 this._grid.features.selection.getSelectedRowsCountByCellRange() ||


### PR DESCRIPTION


This PR fixes an issue where GetChangedLines was not returning values properly.

[Sample page](url)

### What was happening
* GetChangedLines is unable to detect the first row that was added. This seems to have been introduced on #181, where rowStart returned 0 instead of 1.

### What was done
* Added a protection to guarantee that the topRowIndex of newly added row is never negative.

### Test Steps
1. Add row
2. Press save changes
3. Text area should show addedLines with an empty object.

