### PR TITLE
ROU-3366: Adding another way to check if a column should be converted to Date/Datetime

### DIFF
--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -53,7 +53,7 @@ namespace OSFramework.Grid {
                 };
 
                 const handleValue = (value) => {
-                    if (match(value, regex.datetime)) {
+                    if (match(value, regex.datetime) && type === 'DateTime') {
                         return new Date(
                             Date.UTC(
                                 +m[1],
@@ -64,7 +64,7 @@ namespace OSFramework.Grid {
                                 +m[6]
                             )
                         );
-                    } else if (match(value, regex.date)) {
+                    } else if (match(value, regex.date) && type === 'Date') {
                         return new Date(+m[1], +m[2] - 1, +m[3]);
                     } else if (value === '') {
                         return undefined;

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -64,7 +64,10 @@ namespace OSFramework.Grid {
                                 +m[6]
                             )
                         );
-                    } else if (match(value, regex.date) && type === 'Date') {
+                    } else if (
+                        match(value, regex.date) &&
+                        (type === 'Date' || type === 'DateTime')
+                    ) {
                         return new Date(+m[1], +m[2] - 1, +m[3]);
                     } else if (value === '') {
                         return undefined;

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -136,7 +136,7 @@ namespace OSFramework.Grid {
                 ) {
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     //@ts-ignore
-                    entriesToMap(Object.entries(value));
+                    this._entriesToMap(Object.entries(value), map);
                 } else {
                     map.set(key, value);
                 }
@@ -154,12 +154,13 @@ namespace OSFramework.Grid {
             });
         }
 
+        // retrieve map containing column key and type
         private _getTypeMap(metadata) {
             const colTypes = this._parentGrid.getColumnsKeyType();
             if (colTypes.size > 0) {
                 return colTypes;
             } else if (metadata !== undefined) {
-                let typeMap: Map<string, string>;
+                const typeMap = new Map<string, string>();
 
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 //@ts-ignore

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -52,21 +52,33 @@ namespace OSFramework.Grid {
                     convertions.set(type, done);
                 };
 
-                if (match(value, regex.datetime) && type === 'DateTime') {
+                // we want to change the value on date/datetime columns
+                // there are cases where the column is date/datetime, but it has no value ""
+                // on this case we want to return undefined
+                if (type === 'DateTime') {
                     saveConvertion('datetime', key);
-                    return new Date(
-                        Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6])
-                    );
-                } else if (
-                    match(value, regex.date) &&
-                    (type === 'DateTime' || type === 'Date')
-                ) {
+                    if (match(value, regex.datetime)) {
+                        return new Date(
+                            Date.UTC(
+                                +m[1],
+                                +m[2] - 1,
+                                +m[3],
+                                +m[4],
+                                +m[5],
+                                +m[6]
+                            )
+                        );
+                    }
+                    return value === '' ? undefined : value;
+                } else if (type === 'Date') {
                     //Considering that OS Date field do not consider GMT
                     //DataGrid also won't consider it for Date Columns
                     //PS: Datetime will consider GMT just like OS consider
                     saveConvertion('date', key);
-
-                    return new Date(+m[1], +m[2] - 1, +m[3]);
+                    if (match(value, regex.date)) {
+                        return new Date(+m[1], +m[2] - 1, +m[3]);
+                    }
+                    return value === '' ? undefined : value;
                 } else if (value === '') {
                     return undefined;
                 }

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -52,13 +52,16 @@ namespace OSFramework.Grid {
                     convertions.set(type, done);
                 };
 
-                if (match(value, regex.datetime) && type === 'DateTime') {
+                if (
+                    (match(value, regex.datetime) || value === '') &&
+                    type === 'DateTime'
+                ) {
                     saveConvertion('datetime', key);
                     return new Date(
                         Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6])
                     );
                 } else if (
-                    match(value, regex.date) &&
+                    (match(value, regex.date) || value === '') &&
                     (type === 'DateTime' || type === 'Date')
                 ) {
                     //Considering that OS Date field do not consider GMT

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -52,17 +52,14 @@ namespace OSFramework.Grid {
                     convertions.set(type, done);
                 };
 
-                if (
-                    (match(value, regex.datetime) || value === '') &&
-                    type === 'DateTime'
-                ) {
+                if (match(value, regex.datetime) && type === 'DateTime') {
                     saveConvertion('datetime', key);
                     return new Date(
                         Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6])
                     );
                 } else if (
-                    (match(value, regex.date) || value === '') &&
-                    (type === 'DateTime' || type === 'Date')
+                    (match(value, regex.date) && type === 'DateTime') ||
+                    type === 'DateTime'
                 ) {
                     //Considering that OS Date field do not consider GMT
                     //DataGrid also won't consider it for Date Columns

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -52,11 +52,7 @@ namespace OSFramework.Grid {
                     convertions.set(type, done);
                 };
 
-                // we want to change the value on date/datetime columns
-                // there are cases where the column is date/datetime, but it has no value ""
-                // on this case we want to return undefined
-                if (type === 'DateTime') {
-                    saveConvertion('datetime', key);
+                const handleValue = (value) => {
                     if (match(value, regex.datetime)) {
                         return new Date(
                             Date.UTC(
@@ -68,20 +64,26 @@ namespace OSFramework.Grid {
                                 +m[6]
                             )
                         );
+                    } else if (match(value, regex.date)) {
+                        return new Date(+m[1], +m[2] - 1, +m[3]);
+                    } else if (value === '') {
+                        return undefined;
                     }
-                    return value === '' ? undefined : value;
+                    return value;
+                };
+
+                // we want to change the value on date/datetime columns
+                // there are cases where the column is date/datetime, but it has no value ""
+                // on this case we want to return undefined
+                if (type === 'DateTime') {
+                    saveConvertion('datetime', key);
                 } else if (type === 'Date') {
                     //Considering that OS Date field do not consider GMT
                     //DataGrid also won't consider it for Date Columns
                     //PS: Datetime will consider GMT just like OS consider
                     saveConvertion('date', key);
-                    if (match(value, regex.date)) {
-                        return new Date(+m[1], +m[2] - 1, +m[3]);
-                    }
-                    return value === '' ? undefined : value;
-                } else if (value === '') {
-                    return undefined;
                 }
+                return handleValue(value);
             }
             return value;
         });

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -297,14 +297,6 @@ namespace OSFramework.Grid {
         public setData(data: string): void {
             // Use with a Date reviver to restore date fields
             this._convertions.clear();
-
-            // const columns = this._parentGrid.getColumns();
-            // if (columns.length === 0) {
-            //     const metadata = JSON.parse(data).metadata;
-
-            //     const entries = Object.entries(metadata);
-            //     entriesToMap(entries);
-            // }
             const metadata = JSON.parse(data).metadata;
             const typeMap = this._getTypeMap(metadata) || new Map();
             const dataJson = ToJSONFormat(data, this._convertions, typeMap);

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -46,14 +46,14 @@ namespace OSFramework.Grid {
                     return m;
                 };
 
-                const saveConvertion = (type: string, key: string) => {
+                const saveConvertion = (type: string, keyProp: string) => {
                     const done = convertions.get(type) || new Set<string>();
-                    done.add(key);
+                    done.add(keyProp);
                     convertions.set(type, done);
                 };
 
-                const handleValue = (value) => {
-                    if (match(value, regex.datetime) && type === 'DateTime') {
+                const handleValue = (val) => {
+                    if (match(val, regex.datetime) && type === 'DateTime') {
                         return new Date(
                             Date.UTC(
                                 +m[1],
@@ -65,14 +65,14 @@ namespace OSFramework.Grid {
                             )
                         );
                     } else if (
-                        match(value, regex.date) &&
+                        match(val, regex.date) &&
                         (type === 'Date' || type === 'DateTime')
                     ) {
                         return new Date(+m[1], +m[2] - 1, +m[3]);
-                    } else if (value === '') {
+                    } else if (val === '') {
                         return undefined;
                     }
-                    return value;
+                    return val;
                 };
 
                 // we want to change the value on date/datetime columns

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -58,8 +58,8 @@ namespace OSFramework.Grid {
                         Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6])
                     );
                 } else if (
-                    (match(value, regex.date) && type === 'DateTime') ||
-                    type === 'DateTime'
+                    match(value, regex.date) &&
+                    (type === 'DateTime' || type === 'Date')
                 ) {
                     //Considering that OS Date field do not consider GMT
                     //DataGrid also won't consider it for Date Columns

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -41,15 +41,15 @@ namespace OSFramework.Grid {
                 let m: any;
                 const type = typeMap.get(key);
 
-                const match = (value: string, exp: RegExp) => {
-                    m = value.match(exp);
+                const match = (val: string, exp: RegExp) => {
+                    m = val.match(exp);
                     return m;
                 };
 
-                const saveConvertion = (type: string, keyProp: string) => {
-                    const done = convertions.get(type) || new Set<string>();
+                const saveConvertion = (colType: string, keyProp: string) => {
+                    const done = convertions.get(colType) || new Set<string>();
                     done.add(keyProp);
-                    convertions.set(type, done);
+                    convertions.set(colType, done);
                 };
 
                 const handleValue = (val) => {

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -52,12 +52,15 @@ namespace OSFramework.Grid {
                     convertions.set(type, done);
                 };
 
-                if (match(value, regex.datetime) && type === 'Datetime') {
+                if (match(value, regex.datetime) && type === 'DateTime') {
                     saveConvertion('datetime', key);
                     return new Date(
                         Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6])
                     );
-                } else if (match(value, regex.date) && type === 'Datetime') {
+                } else if (
+                    match(value, regex.date) &&
+                    (type === 'DateTime' || type === 'Date')
+                ) {
                     //Considering that OS Date field do not consider GMT
                     //DataGrid also won't consider it for Date Columns
                     //PS: Datetime will consider GMT just like OS consider

--- a/code/src/OSFramework/Grid/AbstractGrid.ts
+++ b/code/src/OSFramework/Grid/AbstractGrid.ts
@@ -139,6 +139,7 @@ namespace OSFramework.Grid {
             });
         }
 
+        // Retrieve column's binding key. (e.g Sample_product.Name -> Name)
         private _getKey(col: Column.IColumn): string {
             const binding = col.config.binding;
             const splittedBinding = binding.split('.');

--- a/code/src/OSFramework/Grid/AbstractGrid.ts
+++ b/code/src/OSFramework/Grid/AbstractGrid.ts
@@ -8,6 +8,7 @@ namespace OSFramework.Grid {
         private _addedRows: Event.Grid.AddNewRowEvent;
         private _columns: Map<string, Column.IColumn>;
         private _columnsGenerator: Column.IColumnGenerator;
+        private _columnsKeyType: Map<string, string>;
         private _columnsSet: Set<Column.IColumn>;
         private _configs: Z;
         private _dataSource: Grid.IDataSource;
@@ -28,6 +29,7 @@ namespace OSFramework.Grid {
             columnsGenerator: Column.IColumnGenerator
         ) {
             this._uniqueId = uniqueId;
+            this._columnsKeyType = new Map<string, string>();
             this._columns = new Map<string, Column.IColumn>();
             this._columnsSet = new Set<Column.IColumn>();
             this._columnsGenerator = columnsGenerator;
@@ -137,6 +139,13 @@ namespace OSFramework.Grid {
             });
         }
 
+        private _getKey(col: Column.IColumn): string {
+            const binding = col.config.binding;
+            const splittedBinding = binding.split('.');
+
+            return splittedBinding[splittedBinding.length - 1];
+        }
+
         private _validateBinding(bindingToValidate: string): void {
             // Split the binding of the column by every dot. (e.g Sample_product.Name -> ['Sample_Product', 'Name'])
             const bindingMatches = bindingToValidate.split('.');
@@ -185,6 +194,7 @@ namespace OSFramework.Grid {
             this._columns.set(col.config.binding, col);
             this._columns.set(col.uniqueId, col);
             this._columnsSet.add(col);
+            this._columnsKeyType.set(this._getKey(col), col.columnType);
         }
 
         public build(): void {
@@ -217,6 +227,10 @@ namespace OSFramework.Grid {
 
         public getColumns(): Column.IColumn[] {
             return Array.from(this._columnsSet);
+        }
+
+        public getColumnsKeyType(): Map<string, string> {
+            return this._columnsKeyType;
         }
 
         public getData(): JSON[] {

--- a/code/src/OSFramework/Grid/IGrid.ts
+++ b/code/src/OSFramework/Grid/IGrid.ts
@@ -45,6 +45,7 @@ namespace OSFramework.Grid {
          * @returns Array of grid's columns
          */
         getColumns(): Column.IColumn[];
+        getColumnsKeyType(): Map<string, string>;
         getData(): JSON[];
         /**
          * Verifies grid has the given Column.

--- a/code/src/OSFramework/Grid/IGrid.ts
+++ b/code/src/OSFramework/Grid/IGrid.ts
@@ -45,6 +45,9 @@ namespace OSFramework.Grid {
          * @returns Array of grid's columns
          */
         getColumns(): Column.IColumn[];
+        /**
+         * Return a map containing all grid's column key and types
+         */
         getColumnsKeyType(): Map<string, string>;
         getData(): JSON[];
         /**

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -280,9 +280,10 @@ namespace WijmoProvider.Feature {
 
             const providerGrid = this._grid.provider;
             const topRowIndex = this._getTopRow();
-            // The datasource index of the selection's top row. Requires the page index and the page size.
-            const dsTopRowIndex =
+            let dsTopRowIndex =
                 topRowIndex + this._grid.features.pagination.rowStart - 1;
+            // we don't want negative indices.
+            dsTopRowIndex = dsTopRowIndex > 0 ? dsTopRowIndex : 0;
             // Consider the quantity 1 if there is no selection.
             const quantity =
                 this._grid.features.selection.getSelectedRowsCountByCellRange() ||


### PR DESCRIPTION
This PR adds another way to check if a column should be converted to Date/Datetime.

[Sample page](url)

### What was happening
* If we had an empty grid and added a a new row with a date format: 2020-20-12. As soon as we saved this using GetChangedLines, this column would be treated as if it were Date/Datetime, because when we were parsing the grid's data, we only looked for a regex match. So any column matching the date/datetime regex would be considered as such.
* Whenever we had an empty grid, added a new row and edited a Date/DateTime column, this value would not come on GetChangedLines. This was happening, because we were not considering empty cells on the ToJSONFormat method.

### What was done
* Created Column <Key, Type> map in order to use on setData.
* Created map from metadata as well.
* These maps will add an extra protection when parsing the JSON, as we should only consider date/dateTime on these respective columns.
* Adjusted ToJSONFormat to consider empty values as well.

### Test Steps

----------------------------------------------------
Column tests 

1. Add row on ArrangeDataColumn Grid
2. Insert 2020-20-12 on the email column
3. Insert any date on DateOfBirth column.
4. Press save all on ArrangeDataColumn Grid

Expected: Both grids on this page should be updated and contain inserted values and no dirty marks.

5. Edit DateOfBirthColumn on ArrangeDataColumn Grid.
6. Press save all on ArrangeDataColumn Grid.
7. Edit DateOfBirthColumn on JSONSerialize Column Grid.
6. Press save all on ArrangeDataColumn Grid.

Expected: Both grids on this page should be updated and contain inserted values and no dirty marks.

9. Press RemoveRow
10. Press save all on ArrangeDataColumn Grid

Expected: Both grids on this page should be empty

----------------------------------------------------
Autogen tests

1. Add row on ArrangeDataAutogen Grid
2. Insert 2020-20-12 on the Name column
3. Insert any date on Created column.
4. Press save all on ArrangeData Autogen 

Expected: Grid should be updated and contain inserted values and no dirty marks.

5. Edit DateOfBirthColumn on ArrangeDataAutogen   Grid.
6. Press save all on ArrangeDataAutogenGrid.

Expected:  Grid should be updated and contain inserted values and no dirty marks.

9. Press RemoveRow
10. Press save all on ArrangeDataAutogenGrid

Expected:  Grid should be empty


