### PR TITLE
ROU-3411 - Improved DirtyMark validation with empty cell

### DIFF
--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -69,7 +69,9 @@ namespace WijmoProvider.Feature {
                     //If the original value and new value are null and undefined we don't want to have dirty mark.
                     if (originalValue === undefined) {
                         return (
-                            originalValue !== cellValue && cellValue !== null
+                            originalValue !== cellValue &&
+                            cellValue !== null &&
+                            cellValue !== ''
                         );
                     } else {
                         //If the cellValue and the originalValue are different we want to add the dirty mark.
@@ -104,7 +106,11 @@ namespace WijmoProvider.Feature {
 
                     //If the original value and new value are null and undefined we don't want to have dirty mark on the cell
                     if (originalValue === undefined) {
-                        if (originalValue === cellValue || cellValue === null) {
+                        if (
+                            originalValue === cellValue ||
+                            cellValue === null ||
+                            cellValue === ''
+                        ) {
                             //Add 1 to the notDirtyCells
                             notDirtyCells++;
                         } else {


### PR DESCRIPTION
This PR is for fixing the DirtyMark validation, when editing an empty cell and leaving it unedited. 

Before, it was still adding a DirtyMark just by double-clicking, without hanging anything.


### Test Steps
[if Grid has now rows or empty cells, add a new one using the button on the top right]
1. Select a empty cell
2. Double Click
3. Write nothing, leave it empty, a click outside of it, to end the editing.


### Screenshots
https://i.imgur.com/Y85FjxU.gif


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

