### PR TITLE
ROU-3397: Remove row was not updating itemsRemoved properly

### DIFF
--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -111,6 +111,26 @@ namespace WijmoProvider.Feature {
             this._oldState = { action: 'insert', items: [...undoableItems] };
             this._newState = undoableItems;
         }
+
+        private _addItemToCollectionView(collectionView, item) {
+            if (collectionView.itemsRemoved.indexOf(item.item) === -1) {
+                collectionView.sourceCollection.splice(item.datasourceIdx, 1);
+                collectionView.trackChanges &&
+                    collectionView.itemsRemoved.push(item.item);
+            }
+        }
+
+        private _removeItemFromCollectionView(collectionView, item) {
+            if (collectionView.itemsRemoved.indexOf(item.item) > -1) {
+                collectionView.sourceCollection.splice(
+                    item.datasourceIdx,
+                    0,
+                    item.item
+                );
+                collectionView.trackChanges &&
+                    collectionView.itemsRemoved.remove(item.item);
+            }
+        }
         // eslint-disable-next-line
         public applyState(state: any): void {
             const collectionView = this._target.itemsSource;
@@ -119,35 +139,15 @@ namespace WijmoProvider.Feature {
                     state.items
                         .sort((a, b) => a.datasourceIdx - b.datasourceIdx)
                         .forEach((item) => {
-                            if (
-                                collectionView.itemsRemoved.indexOf(item.item) >
-                                -1
-                            ) {
-                                collectionView.sourceCollection.splice(
-                                    item.datasourceIdx,
-                                    0,
-                                    item.item
-                                );
-                                collectionView.trackChanges &&
-                                    collectionView.itemsRemoved.remove(
-                                        item.item
-                                    );
-                            }
+                            this._removeItemFromCollectionView(
+                                collectionView,
+                                item
+                            );
                         });
                 } else {
                     //redo
                     state.forEach((item) => {
-                        if (
-                            collectionView.itemsRemoved.indexOf(item.item) ===
-                            -1
-                        ) {
-                            collectionView.sourceCollection.splice(
-                                item.datasourceIdx,
-                                1
-                            );
-                            collectionView.trackChanges &&
-                                collectionView.itemsRemoved.push(item.item);
-                        }
+                        this._addItemToCollectionView(collectionView, item);
                     });
                 }
                 collectionView.refresh();

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -119,25 +119,32 @@ namespace WijmoProvider.Feature {
                     state.items
                         .sort((a, b) => a.datasourceIdx - b.datasourceIdx)
                         .forEach((item) => {
-                            collectionView.sourceCollection.splice(
-                                item.datasourceIdx,
-                                0,
-                                item.item
-                            );
-                            collectionView.trackChanges &&
-                                collectionView.itemsRemoved.remove(item.item);
+                            if (
+                                collectionView.itemsRemoved.indexOf(item.item) >
+                                -1
+                            ) {
+                                collectionView.sourceCollection.splice(
+                                    item.datasourceIdx,
+                                    0,
+                                    item.item
+                                );
+                                collectionView.trackChanges &&
+                                    collectionView.itemsRemoved.remove(
+                                        item.item
+                                    );
+                            }
                         });
                 } else {
                     //redo
                     state.forEach((item) => {
-                        collectionView.sourceCollection.splice(
-                            item.datasourceIdx,
-                            1
-                        );
                         if (
                             collectionView.itemsRemoved.indexOf(item.item) ===
                             -1
                         ) {
+                            collectionView.sourceCollection.splice(
+                                item.datasourceIdx,
+                                1
+                            );
                             collectionView.trackChanges &&
                                 collectionView.itemsRemoved.push(item.item);
                         }

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -110,13 +110,6 @@ namespace WijmoProvider.Feature {
             this._grid = grid;
             this._oldState = { action: 'insert', items: [...undoableItems] };
             this._newState = undoableItems;
-            const collectionView = grid.provider.itemsSource;
-            // clear existing items, because we want to override them with ours
-            collectionView.itemsRemoved.clear();
-            collectionView.trackChanges &&
-                collectionView.itemsRemoved.push(
-                    ...undoableItems.map((undoable) => undoable.item)
-                );
         }
         // eslint-disable-next-line
         public applyState(state: any): void {
@@ -141,8 +134,13 @@ namespace WijmoProvider.Feature {
                             item.datasourceIdx,
                             1
                         );
-                        collectionView.trackChanges &&
-                            collectionView.itemsRemoved.push(item);
+                        if (
+                            collectionView.itemsRemoved.indexOf(item.item) ===
+                            -1
+                        ) {
+                            collectionView.trackChanges &&
+                                collectionView.itemsRemoved.push(item.item);
+                        }
                     });
                 }
                 collectionView.refresh();


### PR DESCRIPTION
This PR fixes an issue where Remove Row was clearing the itemsRemoved array before adding the newly removed row. This caused an issue on GetChangedLines, as it only returned the latest removed row and not the previous ones.


### Test Steps
1. Select a row.
2. Press Remove Selected Rows.
3. Press GetChangedLines.
Expected: The Removed Count should be 1.

1. Select a row.
2. Press Remove Selected Rows
3. Press Ctrl + Z
4. Press GetChangedLines.

Expected: The Removed Count should be 0.

1. Select a row.
2. Press Remove Selected Rows
3. Press Ctrl + Z
4. Press Ctrl + Y
5. Press GetChangedLines.

Expected:  The Removed Count should be 1.

1. Select a row.
2. Press Remove Selected Rows
3. Select another row.
4. Press Remove Selected Rows
5. Press GetChangedLines

Expected: The Removed Count should be 2.

1. Select a row.
2. Press Remove Selected Rows
3. Select another row.
4. Press Remove Selected Rows
5. Press Ctrl + Z
6. Press GetChangedLines

Expected: The Removed Count should be 1.

1. Select a row.
2. Press Remove Selected Rows
3. Select another row.
4. Press Remove Selected Rows
5. Press Ctrl + Z
6. Press Ctrl + Y
7. Press GetChangedLines

Expected: The Removed Count should be 2.


