### PR TITLE
ROU-3404: Added new method to allow JSONSerialized Empty Grids to add new row.

### DIFF
--- a/code/src/OSFramework/Configuration/Column/EditorConfigDate.ts
+++ b/code/src/OSFramework/Configuration/Column/EditorConfigDate.ts
@@ -12,8 +12,8 @@ namespace OSFramework.Configuration.Column {
         // eslint-disable-next-line
         constructor(config: any, isDateTime: boolean) {
             super(config);
-            this.defaultFormat = `${GridAPI.dateFormat} ${
-                isDateTime ? 'HH:mm' : ''
+            this.defaultFormat = `${GridAPI.dateFormat}${
+                isDateTime ? ' HH:mm' : ''
             }`;
 
             this.format = this.format || this.defaultFormat;

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -224,16 +224,28 @@ namespace OSFramework.Grid {
          */
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         protected _parseNewItem(): any {
-            if (!this.hasMetadata && this._ds.length === 0) {
+            if (
+                !this.hasMetadata &&
+                this._ds.length === 0 &&
+                this._parentGrid.getColumns().length === 0
+            ) {
                 throw new Error(Enum.ErrorMessages.UnableToAddRow);
             }
-            const parsedNewItem =
+            let parsedNewItem =
                 _.cloneDeep(this._metadata) ||
                 _.cloneDeep(_.omit(this._ds[0], '__osRowMetadata'));
 
+            parsedNewItem = Object.keys(parsedNewItem).length
+                ? parsedNewItem
+                : this._parentGrid.getStructureFromColumnBindings();
+
             const converter = (object) => {
                 Object.keys(object).forEach((key) => {
-                    if (typeof object[key] === 'object') converter(object[key]);
+                    if (
+                        _.isObject(object[key]) &&
+                        Object.keys(object[key]).length
+                    )
+                        converter(object[key]);
                     else object[key] = undefined;
                 });
             };

--- a/code/src/OSFramework/Grid/AbstractGrid.ts
+++ b/code/src/OSFramework/Grid/AbstractGrid.ts
@@ -139,6 +139,16 @@ namespace OSFramework.Grid {
             });
         }
 
+        private _createObjectFromString(obj, value: string) {
+            const tree = value.split('.');
+            let cur = obj;
+            while (tree.length) {
+                const name = tree.shift();
+                cur[name] = tree.length ? cur[name] || {} : undefined;
+                cur = cur[name];
+            }
+        }
+
         // Retrieve column's binding key. (e.g Sample_product.Name -> Name)
         private _getKey(col: Column.IColumn): string {
             const binding = col.config.binding;
@@ -236,6 +246,22 @@ namespace OSFramework.Grid {
 
         public getData(): JSON[] {
             return this.dataSource.getData();
+        }
+
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+        public getStructureFromColumnBindings(): any {
+            const obj = {};
+            const columns = this.getColumns();
+
+            if (!columns.length) return;
+
+            columns
+                .map((col) => col.config.binding)
+                .filter((colBinding) => !colBinding.startsWith('$')) // remove Action/Calculated columns
+                .forEach((colBinding) =>
+                    this._createObjectFromString(obj, colBinding)
+                );
+            return obj;
         }
 
         public hasColumn(key: string): boolean {

--- a/code/src/OSFramework/Grid/IGrid.ts
+++ b/code/src/OSFramework/Grid/IGrid.ts
@@ -51,6 +51,13 @@ namespace OSFramework.Grid {
         getColumnsKeyType(): Map<string, string>;
         getData(): JSON[];
         /**
+         * This will be used on empty Grids with JSON Serialize
+         * Returns data structure from column bindings.
+         * eg.: Columns = ["Employee.Name", "Employee.Date"] => {Employee: {Name: "", Date: ""}}
+         */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getStructureFromColumnBindings(): any;
+        /**
          * Verifies grid has the given Column.
          * @param key key must be the uniqueId or a binding of a column
          */


### PR DESCRIPTION
This PR adds a new method that will allow JSONSerialized Empty Grids to add new row.


### What was happening
*  JSONSerialized Empty Grids were not able to add new rows, because we couldn't create the new item to be parsed for the new row. This happened because this specific grid didn't have metadata or data at all. 

In order to add new rows into a wijmo Grid, we need to have a clearly defined structure similar to the dataItem itself. 
So for instance, if our Grid receives a JSON containing {Employee: { Data: {Name: ""}}}, we must pass an object containing similar to this to the new row.


### What was done
* Created a new method that iterates our columns, getting the binding and creating an object similar to the dataItem.
* Also fixed an issue with DateFormat where we were returning a trailing space on DateColumns.

### Test Steps
1. Add row
2. Fill all cells from the new row

Expected: New row is added and all cells contain the inputted value.


