### PR TITLE
ROU-3424: GetChangedLines not working properly on empty JSONSerialized Grid

### DIFF
--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -101,8 +101,8 @@ namespace OSFramework.Grid {
     function ToOSFormat(
         convertions: Map<string, Set<string>>,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        data: Array<any>
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        data: Array<any>,
+        columnsType: Map<string, string>
     ): void {
         const dateColumns = convertions.get('date') || new Set();
 
@@ -114,8 +114,11 @@ namespace OSFramework.Grid {
                     setDeepDate(object[key]);
                 }
 
-                // If dateColumns has column and column value is defined, format date
-                if (dateColumns.has(key) && object[key]) {
+                // If column type is date or dateColumns has column and column value is defined, format date
+                if (
+                    (columnsType.get(key) === 'Date' || dateColumns.has(key)) &&
+                    object[key]
+                ) {
                     const dt = object[key] as Date;
                     object[key] = new Date(
                         dt.getTime() - dt.getTimezoneOffset() * 60000
@@ -206,8 +209,9 @@ namespace OSFramework.Grid {
                 return clonedDataItem;
             });
 
+            const columnsType = this.parentGrid.getColumnsKeyType();
             //In-place convert data to Outsystems Format
-            ToOSFormat(this._convertions, tempArray);
+            ToOSFormat(this._convertions, tempArray, columnsType);
 
             if (this.isSingleEntity) {
                 //if the line has a single entity or structure, let's flatten it, so that we avoid the developer


### PR DESCRIPTION
This PR fixes an issue where GetChangedLines was not working properly on empty JSONSerialized Grids. This happened because since there was no data, the ToJSONFormat method was never called and we never define the column as date. So we never treated the date properly, because we were considering it to be Datetime

### Test Steps
1. Add row
2. Fill Date of Birth column
3. Press SaveChanges

Expected: Date of birth should have the filled date.

