### PR TITLE
ROU-3438: Fixing Filter by value

### DIFF
--- a/code/src/WijmoProvider/Features/ColumnFilter.ts
+++ b/code/src/WijmoProvider/Features/ColumnFilter.ts
@@ -189,9 +189,14 @@ namespace WijmoProvider.Feature {
 
                 // we receive values as an array ["Brazil", "Portugal"], but wijmo expects an object
                 // eg.: {Brazil: true, Portugal: true}. So let's transform this to the desired input
-                columnFilter.showValues = values.reduce((obj, cur) => {
-                    return { ...obj, [cur]: true };
-                }, {});
+                columnFilter.showValues = values
+                    .map((val) => {
+                        if (val === null) return '';
+                        return val;
+                    })
+                    .reduce((obj, cur) => {
+                        return { ...obj, [cur]: true };
+                    }, {});
 
                 this._filter.apply();
                 // trigger event


### PR DESCRIPTION
This PR fixes a bug where Filter by value client action was not recognizing empty values.

### Test Steps
1. Make a cell empty on Product Name Grid Client Side
2. Clear Column name input
3. Press FIlter By Value

Expected: Grid client side should show one row where Product Name is empty.

