### PR TITLE
ROU-3429: Formatting date/datetime on JSONSerialize

### DIFF
--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -166,6 +166,20 @@ namespace OSFramework.Grid {
             });
         }
 
+        // remove null date time values from data, as we do not wish to display them.
+        private _formatData(data) {
+            const nullDateTime = ':"1900-01-01T00:00:00"';
+            const nullDate = ':"1900-01-01"';
+            const emptyString = ':""';
+
+            const replaceDateTime = new RegExp(nullDateTime, 'g');
+            const replaceDate = new RegExp(nullDate, 'g');
+
+            return data
+                .replace(replaceDateTime, emptyString)
+                .replace(replaceDate, emptyString);
+        }
+
         private _getRowByKey(key: string) {
             return this._ds.find((item) => {
                 return (
@@ -336,7 +350,12 @@ namespace OSFramework.Grid {
             this._convertions.clear();
             const metadata = JSON.parse(data).metadata;
             const typeMap = this._getTypeMap(metadata) || new Map();
-            const dataJson = ToJSONFormat(data, this._convertions, typeMap);
+            const formatedData = this._formatData(data);
+            const dataJson = ToJSONFormat(
+                formatedData,
+                this._convertions,
+                typeMap
+            );
 
             this._metadata = dataJson.metadata;
             this._isSingleEntity =


### PR DESCRIPTION
This PR fixes a bug on JSONSerialized grids that were not hiding null date/datetime values

### What was done
* Created a formatDate method that replaces all null date/datetime values to an empty string

### Test Steps
1. AddRow on JSONSerialize Column
2. Fill email cell and press save all button

Expected: Row is displayed without dirty mark and DateOfBirth and UpdatedOn cells are empty.

