### PR TITLE
ROU-3450: Adding clear changes client action

### DIFF
--- a/code/src/GridAPI/GridManager.ts
+++ b/code/src/GridAPI/GridManager.ts
@@ -379,6 +379,44 @@ namespace GridAPI.GridManager {
     }
 
     /**
+     * Function that clear all changes in grid
+     *
+     * @export
+     * @param {string} gridID ID of the Grid where the change will occur.
+     */
+    export function ClearChanges(gridID: string): string {
+        PerformanceAPI.SetMark('GridManager.ClearChanges');
+        const responseObj = new OSFramework.OSStructure.ReturnMessage();
+
+        if (!OSFramework.Helper.IsGridReady(gridID)) {
+            responseObj.isSuccess = false;
+            responseObj.message = OSFramework.Enum.ErrorMessages.Grid_NotFound;
+            responseObj.code = OSFramework.Enum.ErrorCodes.CFG_GridNotFound;
+            return JSON.stringify(responseObj);
+        }
+
+        try {
+            GetGridById(gridID).clearChanges();
+            responseObj.isSuccess = true;
+            responseObj.message = OSFramework.Enum.ErrorMessages.SuccessMessage;
+            responseObj.code = OSFramework.Enum.ErrorCodes.GRID_SUCCESS;
+        } catch (error) {
+            responseObj.isSuccess = false;
+            responseObj.message = error.message;
+            responseObj.code =
+                OSFramework.Enum.ErrorCodes.API_FailedClearChanges;
+        }
+
+        PerformanceAPI.SetMark('GridManager.ClearChanges-end');
+        PerformanceAPI.GetMeasure(
+            '@datagrid-GridManager.ClearChanges',
+            'GridManager.ClearChanges',
+            'GridManager.ClearChanges-end'
+        );
+        return JSON.stringify(responseObj);
+    }
+
+    /**
      *
      *
      * @export

--- a/code/src/OSFramework/Enum/ErrorCodes.ts
+++ b/code/src/OSFramework/Enum/ErrorCodes.ts
@@ -51,6 +51,7 @@ namespace OSFramework.Enum {
         API_FailedMarkChangesAsSaved = 'GRID-API-07002',
         API_FailedSetCellData = 'GRID-API-07003',
         API_FailedMarkChangesAsSavedByKey = 'GRID-API-07004',
+        API_FailedClearChanges = 'GRID-API-07005',
         // VALIDATION
         API_FailedSetValidationStatus = 'GRID-API-08001',
         API_FailedSetValidationStatusByKey = 'GRID-API-08002',

--- a/code/src/OSFramework/Feature/IUndoStack.ts
+++ b/code/src/OSFramework/Feature/IUndoStack.ts
@@ -16,10 +16,18 @@ namespace OSFramework.Feature {
          */
         pushAction(action: unknown);
         /**
+         * Redo all actions on undoStack.
+         */
+        redoAll(): void;
+        /**
          * Start an action, normally executed before the changes is made
          * @param action Instance of an action
          */
         startAction(action: unknown);
+        /**
+         * Undo all actions on undoStack.
+         */
+        undoAll(): void;
         /**
          * Getter for the undoStack
          */

--- a/code/src/OSFramework/Grid/AbstractGrid.ts
+++ b/code/src/OSFramework/Grid/AbstractGrid.ts
@@ -345,6 +345,8 @@ namespace OSFramework.Grid {
             forceClearValidationMarks: boolean
         ): void;
 
+        public abstract clearChanges(): void;
+
         public abstract getChangesMade(): OSStructure.ChangesDone;
 
         // public abstract getData(): JSON[];

--- a/code/src/OSFramework/Grid/IGrid.ts
+++ b/code/src/OSFramework/Grid/IGrid.ts
@@ -29,11 +29,21 @@ namespace OSFramework.Grid {
         ): void;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         changeProperty(propertyName: string, propertyValue: any): void;
+        /**
+         * Used to mark all changes as saved. Removes dirty and validation marks from grid.
+         */
         clearAllChanges(forceClearValidationMarks: boolean): void;
+        /**
+         * Used to mark all changes as saved. Removes dirty and validation marks from specific rows.
+         */
         clearAllChangesByRowKeys(
             rowKeys: Array<string>,
             forceClearValidationMarks: boolean
         ): void;
+        /**
+         * Clear all changes from Grid
+         */
+        clearChanges(): void;
         getChangesMade(): OSStructure.ChangesDone;
         /**
          * Get the column on the grid by giving a columnID or a binding.

--- a/code/src/WijmoProvider/Features/UndoStack.ts
+++ b/code/src/WijmoProvider/Features/UndoStack.ts
@@ -16,6 +16,12 @@ namespace WijmoProvider.Feature {
             this._grid = grid;
         }
 
+        private _actionHandler(cb) {
+            for (let index = 0; index < this._undoStack.actionCount; index++) {
+                cb();
+            }
+        }
+
         public get stack(): wijmo.undo.UndoStack {
             return this._undoStack;
         }
@@ -40,8 +46,20 @@ namespace WijmoProvider.Feature {
             this._undoStack.pushAction(action);
         }
 
+        public redoAll(): void {
+            this._actionHandler(() => {
+                this._undoStack.redo();
+            });
+        }
+
         public startAction(action: wijmo.undo.UndoableAction): void {
             this._undoStack._pendingAction = action;
+        }
+
+        public undoAll(): void {
+            this._actionHandler(() => {
+                this._undoStack.undo();
+            });
         }
     }
 }

--- a/code/src/WijmoProvider/Grid/FlexGrid.ts
+++ b/code/src/WijmoProvider/Grid/FlexGrid.ts
@@ -274,6 +274,13 @@ namespace WijmoProvider.Grid {
             }
         }
 
+        public clearChanges(): void {
+            if (this.isReady) {
+                this.features.undoStack.undoAll();
+                this.dataSource.clear();
+            }
+        }
+
         public dispose(): void {
             super.dispose();
 

--- a/code/src/WijmoProvider/Grid/FlexGrid.ts
+++ b/code/src/WijmoProvider/Grid/FlexGrid.ts
@@ -278,6 +278,7 @@ namespace WijmoProvider.Grid {
             if (this.isReady) {
                 this.features.undoStack.undoAll();
                 this.dataSource.clear();
+                this.features.validationMark.clear();
             }
         }
 


### PR DESCRIPTION
This PR adds necessary methods for new Clear Changes client action.

### What was done
* Created new methods to undo/redo all changes in Grid, so whenever the user will use our client action, we’ll undo all changes on the grid in order for them to be cleared as well.

### Test steps
1. Add a row
2. Edit data from a row
3. Remove a row.
4. Press ClearChanges button
5. Press GetChanged Lines button

Expected: Changes will be reverted and cleared and GetChangedLines result will be empty
