### PR TITLE
ROU-3025: [DataGrid] - Initial display of grid with grouping state

### DIFF
--- a/code/src/GridAPI/ColumnManager.ts
+++ b/code/src/GridAPI/ColumnManager.ts
@@ -7,6 +7,52 @@ namespace GridAPI.ColumnManager {
     const columnArr = new Array<OSFramework.Column.IColumn>();
 
     /**
+     * Add a given column to the grid group panel.
+     *
+     * @export
+     * @param {string} gridID ID of the Grid where the change will occur.
+     * @param {string} columnID ID of the Column block that will be programmatically added to the grid group panel.
+     */
+    export function AddColumnsToGroupPanel(
+        gridID: string,
+        ListOfColumnIDs: string
+    ): string {
+        PerformanceAPI.SetMark('ColumnManager.AddColumnToGroupPanel');
+
+        const responseObj = {
+            isSuccess: true,
+            message: OSFramework.Enum.ErrorMessages.SuccessMessage,
+            code: OSFramework.Enum.ErrorCodes.GRID_SUCCESS
+        };
+
+        if (!OSFramework.Helper.IsGridReady(gridID)) {
+            responseObj.isSuccess = false;
+            responseObj.message = OSFramework.Enum.ErrorMessages.Grid_NotFound;
+            responseObj.code = OSFramework.Enum.ErrorCodes.CFG_GridNotFound;
+            return JSON.stringify(responseObj);
+        }
+
+        try {
+            const grid = GridManager.GetGridById(gridID);
+            grid.features.groupPanel.addColumnsToGroupPanel(ListOfColumnIDs);
+        } catch (error) {
+            responseObj.isSuccess = false;
+            responseObj.message = error.message;
+            responseObj.code =
+                OSFramework.Enum.ErrorCodes.API_FailedAddColumnToGroupPanel;
+        }
+
+        PerformanceAPI.SetMark('ColumnManager.AddColumnToGroupPanel-end');
+        PerformanceAPI.GetMeasure(
+            '@datagrid-ColumnManager.AddColumnToGroupPanel',
+            'ColumnManager.AddColumnToGroupPanel',
+            'ColumnManager.AddColumnToGroupPanel-end'
+        );
+
+        return JSON.stringify(responseObj);
+    }
+
+    /**
      * Creates the column for the provider with the given configurations.
      *
      * @param {string} columnID id of the column with which actions on the column can be performed.

--- a/code/src/OSFramework/Enum/ErrorCodes.ts
+++ b/code/src/OSFramework/Enum/ErrorCodes.ts
@@ -69,6 +69,7 @@ namespace OSFramework.Enum {
         API_FailedFreezeColumnsByActiveCell = 'GRID-API-10003',
         API_FailedHasFrozenColumns = 'GRID-API-10004',
         API_FailedUnfreezeColumns = 'GRID-API-10005',
+        API_FailedAddColumnToGroupPanel = 'GRID-API-10006',
         //EXPORT
         API_FailedCustomizeExportingMessage = 'GRID-API-11001',
         //COLUMNPICKER

--- a/code/src/OSFramework/Enum/ErrorCodes.ts
+++ b/code/src/OSFramework/Enum/ErrorCodes.ts
@@ -69,7 +69,7 @@ namespace OSFramework.Enum {
         API_FailedFreezeColumnsByActiveCell = 'GRID-API-10003',
         API_FailedHasFrozenColumns = 'GRID-API-10004',
         API_FailedUnfreezeColumns = 'GRID-API-10005',
-        API_FailedAddColumnToGroupPanel = 'GRID-API-10006',
+        API_FailedAddColumnToGroupPanel = 'GRID-API-10007',
         //EXPORT
         API_FailedCustomizeExportingMessage = 'GRID-API-11001',
         //COLUMNPICKER

--- a/code/src/OSFramework/Feature/IGroupPanel.ts
+++ b/code/src/OSFramework/Feature/IGroupPanel.ts
@@ -4,6 +4,11 @@ namespace OSFramework.Feature {
         /** Boolean that indicates whether the grid is grouped or not */
         isGridGrouped: boolean;
         /**
+         * Add a given column to the grid group panel
+         * @param binding binding of the column
+         */
+        addColumnsToGroupPanel(binding: string): void;
+        /**
          * Check if the column is inside the Group Panel
          * @param binding binding of the column
          */

--- a/code/src/WijmoProvider/Features/GroupPanel.ts
+++ b/code/src/WijmoProvider/Features/GroupPanel.ts
@@ -70,6 +70,34 @@ namespace WijmoProvider.Feature {
                   this._dragCol && this._addGroup(this._dragCol, e);
         }
 
+        public addColumnsToGroupPanel(bindingList: string): void {
+            const groupDescriptions =
+                this._grid.provider.collectionView.groupDescriptions; // Group array
+            const columnList = JSON.parse(bindingList);
+            const source = this._grid.provider.itemsSource;
+            source.deferUpdate(() => {
+                for (let index = 0; index < columnList.length; index++) {
+                    const binding = columnList[index];
+                    const column = this._grid.getColumn(binding);
+                    if (column) {
+                        if (this.columnInGroupPanel(binding) === false) {
+                            const groupDescription =
+                                new wijmo.collections.PropertyGroupDescription(
+                                    binding
+                                );
+
+                            groupDescriptions.push(groupDescription);
+                            column.provider.visible = false;
+                        }
+                    } else {
+                        throw new Error(
+                            OSFramework.Enum.ErrorMessages.InvalidColumnIdentifier
+                        );
+                    }
+                }
+            });
+        }
+
         public build(): void {
             // override wijmo's group panel drop in order to prevent calculated columns being grouped
             wijmo.grid.grouppanel.GroupPanel.prototype._drop = this._drop;
@@ -106,8 +134,11 @@ namespace WijmoProvider.Feature {
         }
 
         public columnInGroupPanel(binding: string): boolean {
-            return this._groupPanel._hiddenCols.some(
-                (col) => col.binding === binding
+            const groupDescriptions =
+                this._grid.provider.collectionView.groupDescriptions; // Group array
+            return groupDescriptions.some(
+                (element: wijmo.collections.PropertyGroupDescription) =>
+                    element.propertyName === binding
             );
         }
 

--- a/code/src/WijmoProvider/Features/GroupPanel.ts
+++ b/code/src/WijmoProvider/Features/GroupPanel.ts
@@ -76,8 +76,7 @@ namespace WijmoProvider.Feature {
             const columnList = JSON.parse(bindingList);
             const source = this._grid.provider.itemsSource;
             source.deferUpdate(() => {
-                for (let index = 0; index < columnList.length; index++) {
-                    const binding = columnList[index];
+                for (const binding of columnList) {
                     const column = this._grid.getColumn(binding);
                     if (column) {
                         if (this.columnInGroupPanel(binding) === false) {


### PR DESCRIPTION
This PR is for an API that allows the developer to add a column to the group panel by its binding.

### What was happening
* In the web version of this component the columns had a parameter that allow the user to config the group panel, but we didn't offer that here until now.

### What was done
* create addColumnsToGroupPanel method;
* change columnInGroupPanel, to access only public attributes;
 

### Test Steps
1. Add the API to a flow;
2. Check if the datagrid changed;
3. Check if its possible to added twice the same column to the group panel;

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems
* [x] requires new sample page in OutSystems 

