### PR TITLE
ROU-3242: Fixing issue on language

### DIFF
--- a/code/src/WijmoProvider/Features/ColumnFilter.ts
+++ b/code/src/WijmoProvider/Features/ColumnFilter.ts
@@ -114,15 +114,7 @@ namespace WijmoProvider.Feature {
                 this.validateAction.bind(this)
             );
 
-            const dateOperators =
-                wijmo.culture.FlexGridFilter.numberOperators.filter(function (
-                    item
-                ) {
-                    //Removing item "Does not Equal"
-                    return item.op !== 1;
-                });
-
-            wijmo.culture.FlexGridFilter.dateOperators = dateOperators;
+            Helper.Translation.FormatDateOperators();
 
             this.setState(this._enabled);
         }

--- a/code/src/WijmoProvider/Helper/Translation.ts
+++ b/code/src/WijmoProvider/Helper/Translation.ts
@@ -22,11 +22,19 @@ namespace WijmoProvider.Helper.Translation {
         return changedLang;
     }
 
-    export function SetLanguage(language: string, url: string): void {
-        // on wijmo version 5.20212.808 and prior, when importing english culture files, the grid has some different resources
-        // than if we used default translation. in order to prevent this, we don't want to import english culture files.
-        if (language === 'en-US' || language.includes('en')) return;
+    export function FormatDateOperators(): void {
+        const dateOperators =
+            wijmo.culture.FlexGridFilter.numberOperators.filter(function (
+                item
+            ) {
+                //Removing item "Does not Equal"
+                return item.op !== 1;
+            });
 
+        wijmo.culture.FlexGridFilter.dateOperators = dateOperators;
+    }
+
+    export function SetLanguage(language: string, url: string): void {
         const regex = new RegExp('culture.(.*)(?=.min)');
         const transposedLanguage = transposeLanguageFormat(language);
 
@@ -46,6 +54,7 @@ namespace WijmoProvider.Helper.Translation {
                         // @ts-ignore
                         gp.placeholder = culture.GroupPanel.dragDrop;
                     }
+                    FormatDateOperators();
                     wijmo.Control.invalidateAll();
                 });
             } else {


### PR DESCRIPTION
This PR fixes a bug where setting the English language was not working on Grid.

### What was done
* Adjusted code to allow Grid to receive the English language.
* Created helper function to customize date operators on language load.

### Test Steps
1. Change grid to "zh-TW".
2. Check if the grid is in Chinese
3. Change grid to "en-us"

Expected: The grid should be in English.


1.  Change grid to "zh-TW".
2. Change grid to "en-us"
3. Open the Date column filter by condition


Expected: Its options should have "(not set)", "Equals", "Is greater than", "Is greater than or equal to", "Is less than" and "Is less than or equal to"

