### PR TITLE
ROU-2927: Fixing Grid clear data

### DIFF
--- a/code/src/GridAPI/GridManager.ts
+++ b/code/src/GridAPI/GridManager.ts
@@ -21,7 +21,10 @@ namespace GridAPI.GridManager {
 
         let output = false;
         if (grid !== undefined) {
-            if (grid.isReady && data !== '' && data !== '{}') {
+            if (grid.isReady) {
+                // in case data comes as an empty string or an empty object, we change it to an empty array
+                // we do this in order to allow Grid to be updated with empty data.
+                data = data === '' || data === '{}' ? '[]' : data;
                 grid.setData(data);
             }
             output = true;


### PR DESCRIPTION
This PR fixes an issue where Grid wasn't rendering properly after clearing data.


### Test Steps
1. Press Clear empty String

Expected: Grid should display "We couldn't find any data to show here." and should not have any rows.


1. Press Clear []

Expected: Grid should display "We couldn't find any data to show here." and should not have any rows.


1. Press Clear {}

Expected: Grid should display "We couldn't find any data to show here." and should not have any rows.


1. Press Clear empty String
2. Press Populate

Expected: Grid should display have all rows and shouldn't display any message;

1. Press Clear {}
2. Press populate

Expected: Grid should display have all rows and shouldn't display any message;


1. Press Clear []
3. Press populate

Expected: Grid should display have all rows and shouldn't display any message;
