### PR TITLE
ROU-3475: Fixing issue with GetChangedLines

### DIFF
--- a/code/src/OSFramework/Feature/IDirtyMark.ts
+++ b/code/src/OSFramework/Feature/IDirtyMark.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Feature {
     export interface IDirtyMark {
+        isGridDirty: boolean;
         clear(): void;
         clearByRowKeys(rowKeys: Array<string>): void;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -8,7 +9,6 @@ namespace OSFramework.Feature {
         clearPropertyInRowByKey(key: string): void;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         getOldValue(rowNumber: number, binding: string): any;
-        isGridDirty(): boolean;
         /**
          * Saves cell original value
          * @param rowNumber Cell's row number

--- a/code/src/OSFramework/Feature/IDirtyMark.ts
+++ b/code/src/OSFramework/Feature/IDirtyMark.ts
@@ -8,6 +8,7 @@ namespace OSFramework.Feature {
         clearPropertyInRowByKey(key: string): void;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         getOldValue(rowNumber: number, binding: string): any;
+        isGridDirty(): boolean;
         /**
          * Saves cell original value
          * @param rowNumber Cell's row number

--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -244,6 +244,12 @@ namespace WijmoProvider.Feature {
             );
         }
 
+        public isGridDirty(): boolean {
+            return this._grid.provider.itemsSource.sourceCollection.some(
+                (row, index) => this._isDirtyRow(index)
+            );
+        }
+
         public saveOriginalValue(
             rowNumber: number,
             columnNumber: number

--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -151,7 +151,7 @@ namespace WijmoProvider.Feature {
 
         public get isGridDirty(): boolean {
             return this._grid.provider.itemsSource.sourceCollection.some(
-                (row, index) => this._isDirtyRow(index)
+                (_row, index) => this._isDirtyRow(index)
             );
         }
 

--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -149,6 +149,12 @@ namespace WijmoProvider.Feature {
             return this.hasMetadata(row) && this.getMetadata(row).isNew;
         }
 
+        public get isGridDirty(): boolean {
+            return this._grid.provider.itemsSource.sourceCollection.some(
+                (row, index) => this._isDirtyRow(index)
+            );
+        }
+
         public build(): void {
             // Responsible for saving the original values before edition of any cell.
             // Essencial for saving the value in case the content of the cell is deleted with keyboard events (del, backspace)
@@ -241,12 +247,6 @@ namespace WijmoProvider.Feature {
             return this._metadata.hasOwnPropertyByRowNumber(
                 rowNumber,
                 this._internalLabel
-            );
-        }
-
-        public isGridDirty(): boolean {
-            return this._grid.provider.itemsSource.sourceCollection.some(
-                (row, index) => this._isDirtyRow(index)
             );
         }
 

--- a/code/src/WijmoProvider/Grid/ProviderDataSource.ts
+++ b/code/src/WijmoProvider/Grid/ProviderDataSource.ts
@@ -36,7 +36,10 @@ namespace WijmoProvider.Grid {
                 );
             }
 
-            if (itemsSource.itemsEdited.length > 0) {
+            if (
+                itemsSource.itemsEdited.length > 0 &&
+                this.parentGrid.features.dirtyMark.isGridDirty()
+            ) {
                 changes.hasChanges = true;
                 changes.editedLinesJSON = this._getChangesString(
                     itemsSource.itemsEdited

--- a/code/src/WijmoProvider/Grid/ProviderDataSource.ts
+++ b/code/src/WijmoProvider/Grid/ProviderDataSource.ts
@@ -38,7 +38,7 @@ namespace WijmoProvider.Grid {
 
             if (
                 itemsSource.itemsEdited.length > 0 &&
-                this.parentGrid.features.dirtyMark.isGridDirty()
+                this.parentGrid.features.dirtyMark.isGridDirty
             ) {
                 changes.hasChanges = true;
                 changes.editedLinesJSON = this._getChangesString(

--- a/code/src/WijmoProvider/Grid/RowMetadata.ts
+++ b/code/src/WijmoProvider/Grid/RowMetadata.ts
@@ -71,7 +71,7 @@ namespace WijmoProvider.Grid {
 
         private _hasMetadataByRowNumber(row: number): boolean {
             return (
-                this._grid.rows[row].dataItem &&
+                this._grid.rows[row]?.dataItem &&
                 this._grid.rows[row].dataItem[this._extraData]
             );
         }


### PR DESCRIPTION
This fixes an issue where GetChangedLines was returning edited lines even though the row had its original value.

### What was happening
* Since we add rowMetadata on the grid's dataItem, wijmo can't tell if the dataItem has been changed or not, because for them the dataItem is always different from the original value.

### What was done
* Created a method that tells if Grid has dirty marks and uses that on GetChangedLines.

### Test Steps
1. Change the Product Category on the first cell.
2. Change back to the original value.
3. Press GetChanged Lines.

Expected: Should return empty values.
