### PR TITLE
ROU-3474: Conditional format didn't work properly with rows.

### DIFF
--- a/code/src/OSFramework/Feature/Auxiliar/RowStyleClassInfo.ts
+++ b/code/src/OSFramework/Feature/Auxiliar/RowStyleClassInfo.ts
@@ -1,0 +1,76 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Feature.Auxiliar {
+    export class RowStyleInfo {
+        /**
+         * Contains all CSS classes from a specific row.
+         */
+        public cssClass: Map<string, Array<string>>;
+
+        constructor() {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            this.cssClass = new Map();
+        }
+
+        private _addClassName(className, binding) {
+            // if element exists, we'll add the class to our existing class Array
+            if (this.cssClass.has(className)) {
+                const rowClasses = this.cssClass.get(className);
+                if (rowClasses.indexOf(binding) === -1) {
+                    this.cssClass.set(className, [...rowClasses, binding]);
+                }
+            }
+            // otherwise, we'll create the element with an array containing the column binding
+            else {
+                this.cssClass.set(className, [binding]);
+            }
+        }
+
+        private _handleClassNames(className, binding, cb) {
+            const classNames = className.split(' ');
+
+            classNames.forEach((name) => {
+                cb(name, binding);
+            });
+        }
+
+        private _removeClassName(className, binding) {
+            if (this.cssClass.has(className)) {
+                const rowClass = this.cssClass.get(className);
+                // if rowClass array is empty or binding is empty, we want to delete the item from our Map
+                // an empty binding means that the class was added through our Styling APIs.
+                if (rowClass.length === 0 || binding === '') {
+                    this.cssClass.delete(className);
+                } else {
+                    if (rowClass.indexOf(binding) > -1) {
+                        rowClass.splice(rowClass.indexOf(binding), 1);
+                    }
+                }
+            }
+        }
+
+        /** Add class to the cssClass array */
+        public addClass(className: string, binding: string): void {
+            this._handleClassNames(
+                className,
+                binding,
+                this._addClassName.bind(this)
+            );
+        }
+
+        /** Remove all classes from the cssClass array */
+        public removeAllClasses(): void {
+            Array.from(this.cssClass.keys()).forEach((key) =>
+                this.cssClass.delete(key)
+            );
+        }
+
+        /** Remove a single class from the cssClass array */
+        public removeClass(className: string, binding: string): void {
+            this._handleClassNames(
+                className,
+                binding,
+                this._removeClassName.bind(this)
+            );
+        }
+    }
+}

--- a/code/src/OSFramework/Feature/IRows.ts
+++ b/code/src/OSFramework/Feature/IRows.ts
@@ -21,7 +21,7 @@ namespace OSFramework.Feature {
          * Clears all the metadata associated to the cssClasses from the row
          */
         clear(): void;
-        getMetadata(rowNumber: number): any;
+        getMetadata(rowNumber: number): Feature.Auxiliar.RowStyleInfo;
         /**
          * Get data from a specific row.
          */

--- a/code/src/OSFramework/Feature/IRows.ts
+++ b/code/src/OSFramework/Feature/IRows.ts
@@ -7,7 +7,12 @@ namespace OSFramework.Feature {
         /**
          * Add a CSS class to a specific row from the grid, refreshing or not the grid
          */
-        addClass(rowNumber: number, className: string, refresh?: boolean);
+        addClass(
+            rowNumber: number,
+            className: string,
+            refresh?: boolean,
+            binding?: string
+        );
         /**
          * Add new rows to the grid. If there is a selection it will add as many rows as selected. If not, it will add a row at the top.
          */
@@ -16,6 +21,7 @@ namespace OSFramework.Feature {
          * Clears all the metadata associated to the cssClasses from the row
          */
         clear(): void;
+        getMetadata(rowNumber: number): any;
         /**
          * Get data from a specific row.
          */
@@ -27,7 +33,12 @@ namespace OSFramework.Feature {
         /**
          * Remove a single class from a specific row, refreshing or not the grid
          */
-        removeClass(rowNumber: number, className: string, refresh?: boolean);
+        removeClass(
+            rowNumber: number,
+            className: string,
+            refresh?: boolean,
+            binding?: string
+        );
         /**
          * Remove the rows that are selected.
          */

--- a/code/src/WijmoProvider/Features/ConditionalFormat.ts
+++ b/code/src/WijmoProvider/Features/ConditionalFormat.ts
@@ -156,14 +156,77 @@ namespace WijmoProvider.Feature {
     }
 
     class ConditionExecuter {
+        private _grid: Grid.IGridWijmo;
         public conditions: Array<ConditionAnd>;
 
-        constructor(conditions: Array<ConditionAnd>) {
+        constructor(conditions: Array<ConditionAnd>, grid: Grid.IGridWijmo) {
             this.conditions = conditions;
+            this._grid = grid;
+        }
+
+        /**
+         * Adds or removes a cell class based on the condition. If the condition is true, we'll add the class, if it's false we'll remove it.
+         * @param columnBinding
+         * @param cellClass
+         * @param rowNumber
+         * @param shouldAdd
+         */
+        private _addOrRemoveCellClass(
+            columnBinding: string,
+            cellClass: string,
+            rowNumber: number,
+            shouldAdd: boolean
+        ) {
+            if (cellClass) {
+                if (shouldAdd) {
+                    this._grid.features.cellStyle.addClass(
+                        columnBinding,
+                        rowNumber,
+                        cellClass
+                    );
+                } else {
+                    this._grid.features.cellStyle.removeClass(
+                        rowNumber,
+                        columnBinding,
+                        cellClass
+                    );
+                }
+            }
+        }
+
+        /**
+         * Adds or removes a row class based on the condition. If the condition is true, we'll add the class, if it's false we'll remove it.
+         * @param columnBinding
+         * @param rowClass
+         * @param rowNumber
+         * @param shouldAdd
+         */
+        private _addOrRemoveRowClass(
+            columnBinding: string,
+            rowClass: string,
+            rowNumber: number,
+            shouldAdd: boolean
+        ) {
+            if (rowClass) {
+                if (shouldAdd) {
+                    this._grid.features.rows.addClass(
+                        rowNumber,
+                        rowClass,
+                        false,
+                        columnBinding
+                    );
+                } else {
+                    this._grid.features.rows.removeClass(
+                        rowNumber,
+                        rowClass,
+                        false,
+                        columnBinding
+                    );
+                }
+            }
         }
 
         public execute(
-            grid: Grid.IGridWijmo,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cellValue: any,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -173,46 +236,29 @@ namespace WijmoProvider.Feature {
             this.conditions
                 .map((condition) => {
                     return {
-                        isTrue: condition.evaluate(cellValue, columnType),
+                        isTrue: condition.evaluate(cellValue, columnType), // add new property telling whether condition is true or false
                         ...condition
                     };
                 })
                 .sort((a, b) => +a.isTrue - +b.isTrue) // sort conditions by true/false
                 .forEach((condition) => {
-                    const binding = grid.provider.getColumn(e.col).binding;
-                    if (condition.isTrue) {
-                        condition.rowClass
-                            ? grid.features.rows.addClass(
-                                  e.row,
-                                  condition.rowClass,
-                                  false,
-                                  binding
-                              )
-                            : null;
-                        condition.cellClass
-                            ? grid.features.cellStyle.addClass(
-                                  binding,
-                                  e.row,
-                                  condition.cellClass
-                              )
-                            : null;
-                    } else {
-                        condition.rowClass
-                            ? grid.features.rows.removeClass(
-                                  e.row,
-                                  condition.rowClass,
-                                  false,
-                                  binding
-                              )
-                            : null;
-                        condition.cellClass
-                            ? grid.features.cellStyle.removeClass(
-                                  e.row,
-                                  binding,
-                                  condition.cellClass
-                              )
-                            : null;
-                    }
+                    const binding = this._grid.provider.getColumn(
+                        e.col
+                    ).binding;
+
+                    this._addOrRemoveRowClass(
+                        binding,
+                        condition.rowClass,
+                        e.row,
+                        condition.isTrue
+                    );
+
+                    this._addOrRemoveCellClass(
+                        binding,
+                        condition.cellClass,
+                        e.row,
+                        condition.isTrue
+                    );
                 });
         }
     }
@@ -245,7 +291,7 @@ namespace WijmoProvider.Feature {
                 );
                 conditionExecuters.push(conditionAnds);
             });
-            return new ConditionExecuter(conditionExecuters);
+            return new ConditionExecuter(conditionExecuters, this._grid);
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
@@ -271,7 +317,6 @@ namespace WijmoProvider.Feature {
                     );
 
                     this._mappedRules.get(column.config.binding).execute(
-                        this._grid,
                         value,
                         {
                             row: index,

--- a/code/src/WijmoProvider/Features/ConditionalFormat.ts
+++ b/code/src/WijmoProvider/Features/ConditionalFormat.ts
@@ -170,43 +170,50 @@ namespace WijmoProvider.Feature {
             e: any,
             columnType: OSFramework.Enum.ColumnType
         ) {
-            this.conditions.some((p) => {
-                const isTrue = p.evaluate(cellValue, columnType);
-                const binding = grid.provider.getColumn(e.col).binding;
-
-                if (isTrue) {
-                    p.rowClass
-                        ? grid.features.rows.addClass(e.row, p.rowClass)
-                        : null;
-                    p.cellClass
-                        ? grid.features.cellStyle.addClass(
-                              binding,
-                              e.row,
-                              p.cellClass
-                          )
-                        : null;
-                } else {
-                    p.rowClass
-                        ? grid.features.rows.removeClass(e.row, p.rowClass)
-                        : null;
-                    p.cellClass
-                        ? grid.features.cellStyle.removeClass(
-                              e.row,
-                              binding,
-                              p.cellClass
-                          )
-                        : null;
-                }
-
-                if (p.cellClass) {
-                    const classes = grid.features.cellStyle
-                        .getMetadata(e.row)
-                        .getCssClassesByBinding(binding);
-                    return isTrue && classes?.length === 0;
-                }
-
-                return isTrue;
-            });
+            this.conditions
+                .map((condition) => {
+                    return {
+                        isTrue: condition.evaluate(cellValue, columnType),
+                        ...condition
+                    };
+                })
+                .sort((a, b) => +a.isTrue - +b.isTrue) // sort conditions by true/false
+                .forEach((condition) => {
+                    const binding = grid.provider.getColumn(e.col).binding;
+                    if (condition.isTrue) {
+                        condition.rowClass
+                            ? grid.features.rows.addClass(
+                                  e.row,
+                                  condition.rowClass,
+                                  false,
+                                  binding
+                              )
+                            : null;
+                        condition.cellClass
+                            ? grid.features.cellStyle.addClass(
+                                  binding,
+                                  e.row,
+                                  condition.cellClass
+                              )
+                            : null;
+                    } else {
+                        condition.rowClass
+                            ? grid.features.rows.removeClass(
+                                  e.row,
+                                  condition.rowClass,
+                                  false,
+                                  binding
+                              )
+                            : null;
+                        condition.cellClass
+                            ? grid.features.cellStyle.removeClass(
+                                  e.row,
+                                  binding,
+                                  condition.cellClass
+                              )
+                            : null;
+                    }
+                });
         }
     }
 

--- a/code/src/WijmoProvider/Features/ConditionalFormat.ts
+++ b/code/src/WijmoProvider/Features/ConditionalFormat.ts
@@ -175,33 +175,37 @@ namespace WijmoProvider.Feature {
                 const binding = grid.provider.getColumn(e.col).binding;
 
                 if (isTrue) {
-                    if (p.rowClass) {
-                        grid.features.rows.addClass(e.row, p.rowClass);
-                    }
-                    if (p.cellClass) {
-                        grid.features.cellStyle.addClass(
-                            binding,
-                            e.row,
-                            p.cellClass
-                        );
-                    }
+                    p.rowClass
+                        ? grid.features.rows.addClass(e.row, p.rowClass)
+                        : null;
+                    p.cellClass
+                        ? grid.features.cellStyle.addClass(
+                              binding,
+                              e.row,
+                              p.cellClass
+                          )
+                        : null;
                 } else {
-                    if (p.rowClass) {
-                        grid.features.rows.removeClass(e.row, p.rowClass);
-                    }
-                    if (p.cellClass) {
-                        grid.features.cellStyle.removeClass(
-                            e.row,
-                            binding,
-                            p.cellClass
-                        );
-                    }
+                    p.rowClass
+                        ? grid.features.rows.removeClass(e.row, p.rowClass)
+                        : null;
+                    p.cellClass
+                        ? grid.features.cellStyle.removeClass(
+                              e.row,
+                              binding,
+                              p.cellClass
+                          )
+                        : null;
                 }
-                const classes = grid.features.cellStyle
-                    .getMetadata(e.row)
-                    .getCssClassesByBinding(binding);
 
-                return isTrue && classes?.length === 0;
+                if (p.cellClass) {
+                    const classes = grid.features.cellStyle
+                        .getMetadata(e.row)
+                        .getCssClassesByBinding(binding);
+                    return isTrue && classes?.length === 0;
+                }
+
+                return isTrue;
             });
         }
     }

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -10,13 +10,17 @@ namespace WijmoProvider.Feature {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             this.cssClass = new Map();
         }
+
         private _addClassName(className, binding) {
+            // if element exists, we'll add the class to our existing class Array
             if (this.cssClass.has(className)) {
                 const rowClasses = this.cssClass.get(className);
                 if (rowClasses.indexOf(binding) === -1) {
                     this.cssClass.set(className, [...rowClasses, binding]);
                 }
-            } else {
+            }
+            // otherwise, we'll create the element with an array containing the column binding
+            else {
                 this.cssClass.set(className, [binding]);
             }
         }
@@ -32,6 +36,8 @@ namespace WijmoProvider.Feature {
         private _removeClassName(className, binding) {
             if (this.cssClass.has(className)) {
                 const rowClass = this.cssClass.get(className);
+                // if rowClass array is empty or binding is empty, we want to delete the item from our Map
+                // an empty binding means that the class was added through our Styling APIs.
                 if (rowClass.length === 0 || binding === '') {
                     this.cssClass.delete(className);
                 } else {

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -296,7 +296,7 @@ namespace WijmoProvider.Feature {
         public addClass(
             rowNumber: number,
             className: string,
-            refresh = false,
+            refresh: boolean,
             binding: string
         ): void {
             this.getMetadata(rowNumber).addClass(className, binding);

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -1,79 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace WijmoProvider.Feature {
-    class CssClassInfo {
-        /**
-         * Contains all CSS classes from a specific row.
-         */
-        public cssClass: Map<string, Array<string>>;
-
-        constructor() {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            this.cssClass = new Map();
-        }
-
-        private _addClassName(className, binding) {
-            // if element exists, we'll add the class to our existing class Array
-            if (this.cssClass.has(className)) {
-                const rowClasses = this.cssClass.get(className);
-                if (rowClasses.indexOf(binding) === -1) {
-                    this.cssClass.set(className, [...rowClasses, binding]);
-                }
-            }
-            // otherwise, we'll create the element with an array containing the column binding
-            else {
-                this.cssClass.set(className, [binding]);
-            }
-        }
-
-        private _handleClassNames(className, binding, cb) {
-            const classNames = className.split(' ');
-
-            classNames.forEach((name) => {
-                cb(name, binding);
-            });
-        }
-
-        private _removeClassName(className, binding) {
-            if (this.cssClass.has(className)) {
-                const rowClass = this.cssClass.get(className);
-                // if rowClass array is empty or binding is empty, we want to delete the item from our Map
-                // an empty binding means that the class was added through our Styling APIs.
-                if (rowClass.length === 0 || binding === '') {
-                    this.cssClass.delete(className);
-                } else {
-                    if (rowClass.indexOf(binding) > -1) {
-                        rowClass.splice(rowClass.indexOf(binding), 1);
-                    }
-                }
-            }
-        }
-
-        /** Add class to the cssClass array */
-        public addClass(className: string, binding): void {
-            this._handleClassNames(
-                className,
-                binding,
-                this._addClassName.bind(this)
-            );
-        }
-
-        /** Remove all classes from the cssClass array */
-        public removeAllClasses(): void {
-            Array.from(this.cssClass.keys()).forEach((key) =>
-                this.cssClass.delete(key)
-            );
-        }
-
-        /** Remove a single class from the cssClass array */
-        public removeClass(className: string, binding: string): void {
-            this._handleClassNames(
-                className,
-                binding,
-                this._removeClassName.bind(this)
-            );
-        }
-    }
-
     export class GridInsertRowAction extends wijmo.undo.UndoableAction {
         private _grid: Grid.IGridWijmo;
 
@@ -408,18 +334,20 @@ namespace WijmoProvider.Feature {
          * @param rowNumber Number of the row to check if there is any metadata associated to the cssClasses.
          * @returns CssClass of the row specified.
          */
-        public getMetadata(rowNumber: number): CssClassInfo {
+        public getMetadata(
+            rowNumber: number
+        ): OSFramework.Feature.Auxiliar.RowStyleInfo {
             if (!this.hasMetadata(rowNumber))
                 this._metadata.setMetadataByRowNumber(
                     rowNumber,
                     this._internalLabel,
-                    new CssClassInfo()
+                    new OSFramework.Feature.Auxiliar.RowStyleInfo()
                 );
 
             return this._metadata.getMetadataByRowNumber(
                 rowNumber,
                 this._internalLabel
-            ) as CssClassInfo;
+            ) as OSFramework.Feature.Auxiliar.RowStyleInfo;
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This PR fixes an issue on the conditional format when we had multiple columns having a conditional format that adds the same rowClass.


### What was happening
* On a grid where we have a text column that is supposed to add “background-yellow” to the cell if it contains silver or grey and a column that adds “background-yellow” if the cell is less than 4000.  ![image](https://user-images.githubusercontent.com/3113318/171174793-6ec8205d-f7a6-4a4b-ba42-1cadef82cc6f.png)
* We would expect all cells to be yellow since they contain grey or silver on the Product Name or have a stock value of less than 4000. But since the last Stock cell is greater than 4000, the class is removed from the row.


### What was done
* Changed the row class metadata to be a Map<ClassName, [ColumnName ]>, so that we can properly know which column has added which class.
* Also changed method to allow insertion of multiple classes in a single string, eg: "red blue".

### Test Steps
1. Fill the element "nameRowClass" with the value "background-green"
2. Then Check if cell first cell of ProductName has a "background-green" class

#
1. Fill the element "nameRowClass" with the value "background-green background-red"
2. Edit the first cell of the ProductName cell with "test"
3. Then Check if cell first cell of ProductName does not have a "background-green" class
4. And Check if cell first cell of ProductName has "background-red" class

#
1. Fill the element "nameRowClass" with the value "background-blue background-pink"
2. Edit the first cell of the Stock cell with 5000
3. Then Check if cell first cell of ProductName does not have a "background-red" class
4. And Check if cell first cell of ProductName has "background-blue background-pink" class



