### PR TITLE
ROU-3473: Adding dynamic height

### DIFF
--- a/code/src/GridAPI/Styling.ts
+++ b/code/src/GridAPI/Styling.ts
@@ -237,7 +237,8 @@ namespace GridAPI.Styling {
     export function SetColumnWordWrap(
         gridID: string,
         columnID: string,
-        wordWrapValue: boolean
+        wordWrapValue: boolean,
+        dynamicHeight: boolean
     ): string {
         PerformanceAPI.SetMark('ColumnManager.SetColumnWordWrap');
 
@@ -257,7 +258,8 @@ namespace GridAPI.Styling {
         try {
             GridManager.GetGridById(gridID).features.styling.setColumnWordWrap(
                 columnID,
-                wordWrapValue
+                wordWrapValue,
+                dynamicHeight
             );
         } catch (error) {
             responseObj.isSuccess = false;

--- a/code/src/OSFramework/Feature/IStyling.ts
+++ b/code/src/OSFramework/Feature/IStyling.ts
@@ -23,6 +23,10 @@ namespace OSFramework.Feature {
          * Set Column word wrap to true
          * @param {string} columnID
          */
-        setColumnWordWrap(columnID: string, value: boolean): void;
+        setColumnWordWrap(
+            columnID: string,
+            value: boolean,
+            dynamicHeight: boolean
+        ): void;
     }
 }

--- a/code/src/WijmoProvider/Features/Styling.ts
+++ b/code/src/WijmoProvider/Features/Styling.ts
@@ -112,11 +112,18 @@ namespace WijmoProvider.Feature {
             }
         }
 
-        public setColumnWordWrap(columnID: string, value: boolean): void {
+        public setColumnWordWrap(
+            columnID: string,
+            value: boolean,
+            dynamicHeight: boolean
+        ): void {
             // validate if column exists
             const column = this._grid.getColumn(columnID);
             if (column) {
                 column.provider.wordWrap = value;
+                if (dynamicHeight) {
+                    this._grid.provider.autoSizeRows();
+                }
             } else {
                 throw new Error(
                     OSFramework.Enum.ErrorMessages.InvalidColumnIdentifier


### PR DESCRIPTION
This PR adds dynamic height param to SetColumnWordWrap client action

### Test Steps
1. Click SetColumnWordWrap (Product.Name) button

Expected: Cells on Product Name should have word wrap and their rows should have their height adjusted.



