### PR TITLE
ROU-3473: Adding dynamic auto row height

### DIFF
--- a/code/src/WijmoProvider/Features/Styling.ts
+++ b/code/src/WijmoProvider/Features/Styling.ts
@@ -122,6 +122,7 @@ namespace WijmoProvider.Feature {
             if (column) {
                 column.provider.wordWrap = value;
                 if (dynamicHeight) {
+                    this._grid.provider.autoRowHeights = dynamicHeight;
                     this._grid.provider.autoSizeRows();
                 }
             } else {


### PR DESCRIPTION
This PR adds dynamic height param to SetColumnWordWrap client action

Test Steps
Click SetColumnWordWrap (Product.Name) button
Expected: Cells on Product Name should have word wrap and their rows should have their height adjusted.


