### PR TITLE
ROU-3499: Fixing GetRowData

### DIFF
--- a/code/src/OSFramework/Enum/RowMetadata.ts
+++ b/code/src/OSFramework/Enum/RowMetadata.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Enum {
+    export enum RowMetadata {
+        Key = '__osRowMetadata',
+        DirtyMark = '__dirtyMarkFeature',
+        Validation = '__validationMarkFeature',
+        CellStyle = '__cellStyle',
+        RowCss = '__rowCssClass'
+    }
+}

--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -251,7 +251,7 @@ namespace OSFramework.Grid {
             }
             let parsedNewItem =
                 _.cloneDeep(this._metadata) ||
-                _.cloneDeep(_.omit(this._ds[0], '__osRowMetadata'));
+                _.cloneDeep(_.omit(this._ds[0], Enum.RowMetadata.Key));
 
             parsedNewItem = Object.keys(parsedNewItem).length
                 ? parsedNewItem

--- a/code/src/WijmoProvider/Features/CellStyle.ts
+++ b/code/src/WijmoProvider/Features/CellStyle.ts
@@ -6,7 +6,8 @@ namespace WijmoProvider.Feature {
             OSFramework.Feature.ICellStyle
     {
         private _grid: Grid.IGridWijmo;
-        private readonly _internalLabel = '__cellStyle';
+        private readonly _internalLabel =
+            OSFramework.Enum.RowMetadata.CellStyle;
         private _metadata: OSFramework.Interface.IRowMetadata;
 
         constructor(grid: Grid.IGridWijmo) {

--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -6,9 +6,9 @@ namespace WijmoProvider.Feature {
             OSFramework.Interface.IBuilder
     {
         private _grid: Grid.IGridWijmo;
-        private readonly _internalLabel = '__dirtyMarkFeature';
+        private readonly _internalLabel =
+            OSFramework.Enum.RowMetadata.DirtyMark;
         private _metadata: OSFramework.Interface.IRowMetadata;
-        private readonly _validationLabel = '__validationMarkFeature';
 
         constructor(grid: Grid.IGridWijmo) {
             this._grid = grid;

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -199,13 +199,11 @@ namespace WijmoProvider.Feature {
         }
 
         private _getDataItemFromRow(rowNumber: number) {
-            const row = this._grid.isSingleEntity
+            return this._grid.isSingleEntity
                 ? OSFramework.Helper.Flatten(
                       this._grid.provider.rows[rowNumber]?.dataItem
                   )
                 : this._grid.provider.rows[rowNumber].dataItem;
-
-            return row;
         }
 
         /**
@@ -391,8 +389,8 @@ namespace WijmoProvider.Feature {
             if (!row) {
                 throw new Error(OSFramework.Enum.ErrorMessages.Row_NotFound);
             }
-            const result = _.omit(row, OSFramework.Enum.RowMetadata.Key); // we must remove our metadata from returned object
-            return result;
+
+            return _.omit(row, OSFramework.Enum.RowMetadata.Key); // we must remove our metadata from returned object;
         }
 
         /**

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -146,7 +146,7 @@ namespace WijmoProvider.Feature {
         private _grid: Grid.IGridWijmo;
 
         /** This is going to be used as a label for the css classes saved on the metadata of the Row */
-        private readonly _internalLabel = '__rowCssClass';
+        private readonly _internalLabel = OSFramework.Enum.RowMetadata.RowCss;
 
         private _metadata: OSFramework.Interface.IRowMetadata;
 
@@ -196,6 +196,16 @@ namespace WijmoProvider.Feature {
                     wijmo.addClass(e.cell, cssClass);
                 }
             }
+        }
+
+        private _getDataItemFromRow(rowNumber: number) {
+            const row = this._grid.isSingleEntity
+                ? OSFramework.Helper.Flatten(
+                      this._grid.provider.rows[rowNumber]?.dataItem
+                  )
+                : this._grid.provider.rows[rowNumber].dataItem;
+
+            return row;
         }
 
         /**
@@ -376,16 +386,13 @@ namespace WijmoProvider.Feature {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getRowData(rowNumber: number): any {
-            const row = this._grid.isSingleEntity
-                ? OSFramework.Helper.Flatten(
-                      this._grid.provider.rows[rowNumber]?.dataItem
-                  )
-                : this._grid.provider.rows[rowNumber].dataItem;
+            const row = this._getDataItemFromRow(rowNumber);
 
             if (!row) {
                 throw new Error(OSFramework.Enum.ErrorMessages.Row_NotFound);
             }
-            return row;
+            const result = _.omit(row, OSFramework.Enum.RowMetadata.Key); // we must remove our metadata from returned object
+            return result;
         }
 
         /**

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -7,7 +7,8 @@ namespace WijmoProvider.Feature {
     {
         private _grid: Grid.IGridWijmo;
         /** Internal label for the validation marks */
-        private readonly _internalLabel = '__validationMarkFeature';
+        private readonly _internalLabel =
+            OSFramework.Enum.RowMetadata.Validation;
         /** Array containing all invalid rows */
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         private _invalidRows: Array<any>;

--- a/code/src/WijmoProvider/Grid/RowMetadata.ts
+++ b/code/src/WijmoProvider/Grid/RowMetadata.ts
@@ -3,7 +3,7 @@ namespace WijmoProvider.Grid {
     export class RowMetadata implements OSFramework.Interface.IRowMetadata {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         private _configs: any;
-        private readonly _extraData = '__osRowMetadata';
+        private readonly _extraData = OSFramework.Enum.RowMetadata.Key;
         private _grid: wijmo.grid.FlexGrid;
         private _itemsSource: wijmo.collections.CollectionView;
 


### PR DESCRIPTION
This PR fixes an issue where GetRowData was returning row metadata. This PR also created a RowMetadata Enum.

### Test Steps
1. Press GetRowData Valid

Expected: Result should not contain __osRowMetadata":{}

