### PR TITLE
ROU-3520: Calculated column

### DIFF
--- a/code/src/WijmoProvider/Columns/CalculatedColumn.ts
+++ b/code/src/WijmoProvider/Columns/CalculatedColumn.ts
@@ -24,7 +24,7 @@ namespace WijmoProvider.Column {
             // eg.: $Average_423432413123
             this.config.binding =
                 '$' +
-                this.config.header.replace(/[^a-zA-Z]+/g, '') +
+                this.config.header.replace(/[^a-zA-Z_0-9-]/g, '') +
                 '_' +
                 extraConfig.formula.function;
         }


### PR DESCRIPTION
Fixed issue where calculated columns with similar names didn't work properly.

### Test Steps
1. Change the first cell of the Price column to 20
2. Change the first cell of In Stock column to 4

Expected: Column Sum should have 34 on the first cell, Sum1 should have 25 and Sum2 should have 26.
