### PR TITLE
ROU-3536: Changing dropdown cell change

### DIFF
--- a/code/src/WijmoProvider/Columns/DropdownColumn.ts
+++ b/code/src/WijmoProvider/Columns/DropdownColumn.ts
@@ -132,7 +132,7 @@ namespace WijmoProvider.Column {
         }
 
         private _parentCellValueChangeHandler(
-            gridID: string,
+            _gridID: string,
             rowNumber: number,
             columnID: string,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -146,7 +146,7 @@ namespace WijmoProvider.Column {
                 const currentValue = this.grid.provider.getCellData(
                     rowNumber,
                     this.provider.index,
-                    true
+                    false
                 );
 
                 this.grid.features.dirtyMark.saveOriginalValue(

--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -54,10 +54,7 @@ namespace WijmoProvider.Feature {
             const grid = this._grid.provider;
             if (this.hasMetadata(row)) {
                 const binding = grid.getColumn(col).binding;
-                const columnType = this._grid.getColumn(binding)?.columnType;
-                const isDropdown =
-                    columnType === OSFramework.Enum.ColumnType.Dropdown;
-                const cellValue = grid.getCellData(row, col, isDropdown); // on dropdown columns we want formatted value
+                const cellValue = grid.getCellData(row, col, false);
                 const metadata = this.getMetadata(row);
 
                 //If the cell isNew we want to have the dirty mark
@@ -93,14 +90,11 @@ namespace WijmoProvider.Feature {
                 let notDirtyCells = 0;
 
                 for (const k of metadata.originalValues.keys()) {
-                    const columnType = this._grid.getColumn(k)?.columnType;
-                    const isDropdown =
-                        columnType === OSFramework.Enum.ColumnType.Dropdown;
                     // on dropdown columns we want formatted value
                     const cellValue = this._grid.provider.getCellData(
                         row,
                         k,
-                        isDropdown
+                        false
                     );
                     const originalValue = metadata.originalValues.get(k);
 
@@ -260,15 +254,12 @@ namespace WijmoProvider.Feature {
                 !this._isNewRow(rowNumber) &&
                 !this._hasCellInitialValue(rowNumber, binding)
             ) {
-                const columnType = this._grid.getColumn(binding)?.columnType;
-                const isDropdown =
-                    columnType === OSFramework.Enum.ColumnType.Dropdown;
                 this.getMetadata(rowNumber).originalValues.set(
                     binding,
                     this._grid.provider.getCellData(
                         rowNumber,
                         columnNumber,
-                        isDropdown
+                        false
                     )
                 );
             }

--- a/code/src/WijmoProvider/Features/ValidationMark.ts
+++ b/code/src/WijmoProvider/Features/ValidationMark.ts
@@ -50,12 +50,14 @@ namespace WijmoProvider.Feature {
                 e.row,
                 column.binding
             );
-            this._triggerEventsFromColumn(
-                e.row,
-                OSColumn.uniqueId,
-                oldValue,
-                newValue
-            );
+            if (oldValue !== newValue) {
+                this._triggerEventsFromColumn(
+                    e.row,
+                    OSColumn.uniqueId,
+                    oldValue,
+                    newValue
+                );
+            }
         }
 
         /** Helper to convert the formats of Date and DateTime columns to the format of OS */


### PR DESCRIPTION
This PR changes the dropdown column's cell change event to return the id instead of the label.

### Test Steps
1. Change any cell from the Product Category
2. The Old Value and New Value should be the Id of the column instead of the text.
