### PR TITLE
ROU-3538: Fixing OnInitialize event

### DIFF
--- a/code/src/OSFramework/Grid/AbstractGrid.ts
+++ b/code/src/OSFramework/Grid/AbstractGrid.ts
@@ -123,6 +123,7 @@ namespace OSFramework.Grid {
             }
         }
 
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         private _buildColumnsAndTriggerInitializedEvent(columns: any[]): void {
             Promise.all(columns.map((p) => this.addColumn(p))).then(() => {
                 this.gridEvents.trigger(

--- a/code/src/OSFramework/Grid/AbstractGrid.ts
+++ b/code/src/OSFramework/Grid/AbstractGrid.ts
@@ -101,14 +101,14 @@ namespace OSFramework.Grid {
                     this.config.allowEdit
                 );
                 const newColumns = this._checkForNewColumns();
-                // remove existing columns if new dataSource has different columns
-                if (this._columns.size > 0 && newColumns) {
-                    this._columns.forEach((p) => this.removeColumn(p.uniqueId));
-                    generated.forEach((p) => this.addColumn(p));
-                }
-                // generate new columns
-                if (this._columns.size === 0 && newColumns) {
-                    generated.forEach((p) => this.addColumn(p));
+                if (newColumns) {
+                    // remove existing columns if new dataSource has different columns
+                    if (this._columns.size > 0) {
+                        this._columns.forEach((p) =>
+                            this.removeColumn(p.uniqueId)
+                        );
+                    }
+                    this._buildColumnsAndTriggerInitializedEvent(generated);
                 }
             } else {
                 //if the grid is read-only, then we'll flatten the array and use wijmo generator
@@ -121,6 +121,15 @@ namespace OSFramework.Grid {
                     );
                 }
             }
+        }
+
+        private _buildColumnsAndTriggerInitializedEvent(columns: any[]): void {
+            Promise.all(columns.map((p) => this.addColumn(p))).then(() => {
+                this.gridEvents.trigger(
+                    Event.Grid.GridEventType.Initialized,
+                    this
+                );
+            });
         }
 
         private _checkForNewColumns(): boolean {
@@ -194,14 +203,18 @@ namespace OSFramework.Grid {
                 });
             }
         }
+
         protected finishBuild(): void {
             this._isReady = true;
-
-            this.gridEvents.trigger(Event.Grid.GridEventType.Initialized, this);
+            if (this.hasColumnsDefined()) {
+                this.gridEvents.trigger(
+                    Event.Grid.GridEventType.Initialized,
+                    this
+                );
+            }
         }
 
         public addColumn(col: Column.IColumn): void {
-            console.log(`Add column '${col.uniqueId}': '${col.config.header}'`);
             this._columns.set(col.config.binding, col);
             this._columns.set(col.uniqueId, col);
             this._columnsSet.add(col);
@@ -313,7 +326,6 @@ namespace OSFramework.Grid {
                 } else {
                     this._validateBindings();
                 }
-
                 return true;
             }
 

--- a/code/src/OSFramework/Helper/AsyncInvocation.ts
+++ b/code/src/OSFramework/Helper/AsyncInvocation.ts
@@ -1,5 +1,19 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Helper {
+    export function AsyncInvocationPromise(
+        callback: Callbacks.Generic,
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+        ...args: any
+    ): Promise<void> {
+        if (callback) {
+            return new Promise((resolve) =>
+                setTimeout(() => {
+                    resolve(callback(...args));
+                }, 0)
+            );
+        }
+    }
+
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
     export function AsyncInvocation(callback: Callbacks.Generic, ...args: any) {
         if (callback) setTimeout(() => callback(...args), 0);

--- a/code/src/WijmoProvider/Grid/FlexGrid.ts
+++ b/code/src/WijmoProvider/Grid/FlexGrid.ts
@@ -94,12 +94,14 @@ namespace WijmoProvider.Grid {
             return this._rowMetadata;
         }
 
-        public addColumn(col: OSFramework.Column.IColumn): void {
+        public addColumn(col: OSFramework.Column.IColumn): Promise<void> {
             super.addColumn(col);
 
             if (this.isReady) {
                 //OS takes a while to set the WidgetId
-                OSFramework.Helper.AsyncInvocation(col.build.bind(col));
+                return OSFramework.Helper.AsyncInvocationPromise(
+                    col.build.bind(col)
+                );
             }
         }
 


### PR DESCRIPTION
This PR fixes a bug where OnInitialize event was being triggered incorrectly on Grids. 

There were two scenarios happening: 
1. Autogenerated grids triggered the event before the columns were created. This caused many client actions to not work properly on the event, as they were doing some changes on columns.
2. In some cases, the event was triggered before the Grid was ready, which led to inconsistent behavior.

### Test Steps
1. Both text areas should show the last column name.
2. Press F5 multiple times. And check if the names are there.

