### PR TITLE
ROU-3593: Fix ContextMenu event and right click on empty-message

### DIFF
--- a/code/src/WijmoProvider/Features/ContextMenu.ts
+++ b/code/src/WijmoProvider/Features/ContextMenu.ts
@@ -231,10 +231,11 @@ namespace WijmoProvider.Feature {
             // Trigger to open
             this._isOpening = true;
             const columns = this._grid.getColumns();
+            const htColumn = ht.getColumn();
 
-            if (columns.length) {
+            if (columns.length && htColumn) {
                 this._columnUniqueId = this._grid.getColumns().find((x) => {
-                    return x.config.binding === ht.getColumn().binding;
+                    return x.config.binding === htColumn.binding;
                 }).uniqueId;
             }
 

--- a/code/styles/Grid.css
+++ b/code/styles/Grid.css
@@ -792,6 +792,7 @@
     display: flex;
     justify-content: center;
     left: 0;
+    pointer-events: none;
     position: absolute;
     right: 0;
     z-index: 1;


### PR DESCRIPTION
This PR is for fixing two issues:

1. When the grid has less rows than the available height, right-clicking to open the ContextMenu on the empty space would trigger console errors and wouldn't open the menu. This was due to trying to find the binding of a non-existent column.
2. The empty-message is absolute with z-index:1, which was preventing the right-click to open the ContextMenu to work.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

