### PR TITLE
ROU-3592: Fixing issue with getchangedLines

### DIFF
--- a/code/src/OSFramework/Feature/IDirtyMark.ts
+++ b/code/src/OSFramework/Feature/IDirtyMark.ts
@@ -9,6 +9,7 @@ namespace OSFramework.Feature {
         clearPropertyInRowByKey(key: string): void;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         getOldValue(rowNumber: number, binding: string): any;
+        isRowDirty(row: number): boolean;
         /**
          * Saves cell original value
          * @param rowNumber Cell's row number

--- a/code/src/WijmoProvider/Features/DirtyMark.ts
+++ b/code/src/WijmoProvider/Features/DirtyMark.ts
@@ -20,7 +20,7 @@ namespace WijmoProvider.Feature {
         }
 
         private _cellEditHandler(
-            grid: wijmo.grid.FlexGrid,
+            _grid: wijmo.grid.FlexGrid,
             e: wijmo.grid.CellRangeEventArgs
         ): void {
             this.saveOriginalValue(e.row, e.col);
@@ -242,6 +242,10 @@ namespace WijmoProvider.Feature {
                 rowNumber,
                 this._internalLabel
             );
+        }
+
+        public isRowDirty(row: number): boolean {
+            return this._isDirtyRow(row);
         }
 
         public saveOriginalValue(

--- a/code/src/WijmoProvider/Grid/ProviderDataSource.ts
+++ b/code/src/WijmoProvider/Grid/ProviderDataSource.ts
@@ -4,6 +4,17 @@ namespace WijmoProvider.Grid {
         .AbstractDataSource {
         private _provider: wijmo.collections.CollectionView;
 
+        private _getDirtyEditedItems() {
+            const itemsSource = this._provider;
+            return itemsSource.itemsEdited.filter((editedItem) => {
+                const rowIndex = itemsSource.sourceCollection.findIndex(
+                    (item) => item === editedItem
+                );
+
+                return this._parentGrid.features.dirtyMark.isRowDirty(rowIndex);
+            });
+        }
+
         public addRow(position?: number, data?: JSON[]): void {
             super.addRow(position, data);
             this._provider.refresh();
@@ -40,10 +51,10 @@ namespace WijmoProvider.Grid {
                 itemsSource.itemsEdited.length > 0 &&
                 this.parentGrid.features.dirtyMark.isGridDirty
             ) {
+                const dirtyEditedItems = this._getDirtyEditedItems();
                 changes.hasChanges = true;
-                changes.editedLinesJSON = this._getChangesString(
-                    itemsSource.itemsEdited
-                );
+                changes.editedLinesJSON =
+                    this._getChangesString(dirtyEditedItems);
             }
 
             if (itemsSource.itemsRemoved.length > 0) {


### PR DESCRIPTION
This PR fixes an issue where GetChangedLines was returning two edited rows when only one was added. This was caused by inconsistency on wijmo's side, but it is now addressed here.


### Test Steps
1. Edit Price cell on first row.
2. Open edition on Product Name cell on second row, but don't make any change and press Enter.
3. Press GetChangedLines

Expected: The result should contain only the first row.
