### PR TITLE
ROU-3646: Fixing GetSelectedRowsData

### DIFF
--- a/code/src/OSFramework/Grid/AbstractDataSource.ts
+++ b/code/src/OSFramework/Grid/AbstractDataSource.ts
@@ -215,8 +215,11 @@ namespace OSFramework.Grid {
             }
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        protected _getChangesString(itemsChanged: any): string {
+        protected _getChangesString(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+            itemsChanged: any,
+            stringify = true
+        ): string {
             let tempArray = itemsChanged.map((p) => {
                 const clonedDataItem = _.cloneDeep(p);
                 this._parentGrid.rowMetadata.clear(clonedDataItem);
@@ -231,6 +234,10 @@ namespace OSFramework.Grid {
                 //if the line has a single entity or structure, let's flatten it, so that we avoid the developer
                 //when deserializing to need to put in the JSONDeserialize in the target "List Record {ENTITY}" -> would require extra step.
                 tempArray = FlattenArray(tempArray);
+            }
+
+            if (!stringify) {
+                return tempArray;
             }
 
             return JSON.stringify(tempArray);
@@ -369,8 +376,8 @@ namespace OSFramework.Grid {
         }
 
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public toOSFormat(dataItem: any): any {
-            return this._getChangesString([dataItem]);
+        public toOSFormat(dataItem: any, stringify = true): any {
+            return this._getChangesString([dataItem], stringify);
         }
 
         public trimSecondsFromDate(value: string): string {

--- a/code/src/OSFramework/Interface/IDataSource.ts
+++ b/code/src/OSFramework/Interface/IDataSource.ts
@@ -82,7 +82,7 @@ namespace OSFramework.Grid {
          * @param dataItem
          */
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        toOSFormat(dataItem: any): any;
+        toOSFormat(dataItem: any, stringify?: boolean): any;
         /**
          * Removes the second to dates in string format because the Datetime picker format is HH:mm
          * @param value

--- a/code/src/OSFramework/OSStructure/RowData.ts
+++ b/code/src/OSFramework/OSStructure/RowData.ts
@@ -31,11 +31,18 @@ namespace OSFramework.OSStructure {
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public serialize(): any {
+        public serialize(hasDataItem = true): any {
+            if (!hasDataItem) {
+                return {
+                    rowIndex: this.rowIndex,
+                    selected: this.selected
+                };
+            }
+
             return {
                 rowIndex: this.rowIndex,
                 selected: this.selected,
-                dataItem: this._grid.dataSource.toOSFormat(this.dataItem)
+                dataItem: this._grid.dataSource.toOSFormat(this.dataItem, false)
             };
         }
     }

--- a/code/src/WijmoProvider/Features/Selection.ts
+++ b/code/src/WijmoProvider/Features/Selection.ts
@@ -256,7 +256,7 @@ namespace WijmoProvider.Feature {
                     number,
                     OSFramework.OSStructure.RowData
                 >();
-                const rowColumnArr = [];
+                const rowColumnArr: OSFramework.OSStructure.RowData[] = [];
 
                 this.getProviderAllSelections().map((range) => {
                     const bindings = Array(range.rightCol - range.leftCol + 1)
@@ -468,7 +468,18 @@ namespace WijmoProvider.Feature {
                         )
                 );
                 return {
-                    value: selectedRows.map((p) => p.serialize()),
+                    value: selectedRows
+                        .map((p) => p.serialize())
+                        // we want to return dataItem as an object instead of an array,
+                        .map(({ rowIndex, selected, dataItem }) => {
+                            const _dataItem = { ...dataItem[0] };
+
+                            return {
+                                rowIndex,
+                                selected,
+                                dataItem: JSON.stringify(_dataItem)
+                            };
+                        }),
                     isSuccess: true,
                     message: OSFramework.Enum.ErrorMessages.SuccessMessage,
                     code: OSFramework.Enum.ErrorCodes.GRID_SUCCESS


### PR DESCRIPTION
Fixing issue where we returned row's dataItem as an array instead of an object.

### Test Steps
1. Select two rows.
2. Press GetSelectedRowsData button

Expected: Result should contain dataItem as an object instead of an array. Eg.: {"dataItem":"{ ...."


