### PR TITLE
Fix error on the console when right-clicking on the column picker

### DIFF
--- a/code/src/WijmoProvider/Features/ContextMenu.ts
+++ b/code/src/WijmoProvider/Features/ContextMenu.ts
@@ -233,7 +233,8 @@ namespace WijmoProvider.Feature {
             const columns = this._grid.getColumns();
             const htColumn = ht.getColumn();
 
-            if (columns.length && htColumn) {
+            // Will need to have an extra validation looking at the binding because of the column picker column
+            if (columns.length && htColumn && htColumn.binding !== null) {
                 this._columnUniqueId = this._grid.getColumns().find((x) => {
                     return x.config.binding === htColumn.binding;
                 }).uniqueId;


### PR DESCRIPTION
This PR is to fix an error on the console when right-clicking on the column picker.

### What was happening
* Error on the console when doing right-click on the column picker:
![RightClick](https://user-images.githubusercontent.com/29493222/182907821-1575581c-22a3-4987-8f74-e5d00e693740.gif)


### What was done
* Added an extra validation to exclude columns without binding

### Test Steps
1. Right-click on the column picker
2. Check that no errors are displayed on the console


### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

