### PR TITLE
ROU-3674: Fixing AddRows

### DIFF
--- a/code/src/OSFramework/Enum/ErrorMessages.ts
+++ b/code/src/OSFramework/Enum/ErrorMessages.ts
@@ -20,6 +20,7 @@ namespace OSFramework.Enum {
         SuccessMessage = 'Success',
         UnableToAddRow = 'Unable to add row. Please use ArrangeData action to serialize your data.',
         AddRowGreaterThanPageSize = 'It seems that you are trying to add an invalid amount of rows. The NumberOfRows must be less or equal to the RowsPerPage.',
+        AddRowExceedingPageSize = "You can't add this amount of rows on the selected row, because this client action only works with the visible page. You can either change the NumberOfRows amount or select another row.",
         AddRowLowerThanOne = 'It seems that you are trying to add an invalid amount of rows. The NumberOfRows must greater than 0.',
         ReorderRowWithActiveSort = "It seems you are trying to reorder rows when grid is sorted. Grid can't be sorted.",
         ReorderRowOnGridWithCheckbox = 'It seems you are trying to reorder rows on a grid with checkboxes. This is not allowed'

--- a/code/src/WijmoProvider/Features/Rows.ts
+++ b/code/src/WijmoProvider/Features/Rows.ts
@@ -234,7 +234,7 @@ namespace WijmoProvider.Feature {
             return topRow === Infinity ? 0 : topRow;
         }
 
-        private _validateAddNewRow(rowsAmount: number): void {
+        private _validateAddNewRow(rowsAmount: number, topRowIndex: number): void {
             if (!this._canAddRows()) {
                 throw new Error(
                     OSFramework.Enum.ErrorMessages.AddRowWithActiveFilterOrSort
@@ -245,6 +245,10 @@ namespace WijmoProvider.Feature {
                 throw new Error(
                     OSFramework.Enum.ErrorMessages.AddRowLowerThanOne
                 );
+            }
+
+            if(rowsAmount + topRowIndex > this._grid.features.pagination.pageSize){
+                throw new Error(OSFramework.Enum.ErrorMessages.AddRowExceedingPageSize);
             }
 
             // on serverSideGrids we don't have control of pageSize,
@@ -281,10 +285,10 @@ namespace WijmoProvider.Feature {
          * @returns ReturnMessage containing the resulting code from the adding rows and the error message in case of failure.
          */
         public addNewRows(rowsAmount: number): void {
-            this._validateAddNewRow(rowsAmount);
-
             const providerGrid = this._grid.provider;
             const topRowIndex = this._getTopRow();
+            
+            this._validateAddNewRow(rowsAmount, topRowIndex);
             // The datasource index of the selection's top row. Requires the page index and the page size.
             let dsTopRowIndex =
                 topRowIndex + this._grid.features.pagination.rowStart - 1;


### PR DESCRIPTION
This PR is for add a new validation for when the number of added row does not fit in the current grid page.

### What was happening
* The added rows were exceeding to the next grid page when it exceeds the RowsPerPage number.

### What was done
* Added a new validation in _validateAddNewRow method
* Verifies if the amount of new rows plus the selected row index is greater than the max rows per page. If true, throw an error, otherwise, do nothing.
* New error message for this case.

### Test Steps
1. Click on the last row of the page and try to add 2 new rows. Expect to throw an error.
2. Click on the first row and try to add a greater amount of rows than the page limit. Expect to throw an error.
3. Click on the first row and try to add the same amount of rows as the page limit. Expect to add all new rows.

### Checklist
* [x] tested locally
* [ ] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

