### PR TITLE
ROU-3673: Improving undo add rows performance

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/Rows.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Rows.ts
@@ -25,17 +25,13 @@ namespace Providers.DataGrid.Wijmo.Feature {
             if (collectionView) {
                 if (state.action === 'remove') {
                     //undo
-                    OSFramework.DataGrid.Helper.BatchArray(
-                        state.items,
-                        (chunk) => {
-                            collectionView.sourceCollection.splice(
-                                state.datasourceIdx,
-                                chunk.length
-                            );
-                            chunk.forEach((item) => {
-                                collectionView.itemsAdded.remove(item);
-                            });
-                        }
+                    collectionView.sourceCollection.splice(
+                        state.datasourceIdx,
+                        state.items.length
+                    );
+                    collectionView.itemsAdded.splice(
+                        state.items.length,
+                        state.items.length
                     );
                 } else {
                     //redo

--- a/src/Providers/DataGrid/Wijmo/Features/Rows.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Rows.ts
@@ -29,8 +29,16 @@ namespace Providers.DataGrid.Wijmo.Feature {
                         state.datasourceIdx,
                         state.items.length
                     );
+
+                    // our index is the existing itemsAdded length minus state.items.
+                    // so if want to remove 3 items and we have 12 in itemsAdded.
+                    // we want to remove the last 3, so our starting index is 12 (itemsAdded.length) - 3 (state.items.length)
+                    // which is 9.
+                    const startingIndex =
+                        collectionView.itemsAdded.length - state.items.length;
+
                     collectionView.itemsAdded.splice(
-                        state.items.length,
+                        startingIndex,
                         state.items.length
                     );
                 } else {


### PR DESCRIPTION
This PR improves undo add rows performance.

### What was happening
* We were using collectionView.remove, which iterates over array to find item index and them eventually uses splice to remove it.

### What was done
* Changed the itemsAdded removal to splice directly, since we can find out the starting index from beginning.
