### PR TITLE
ROU-3764: Fixing wrong removal of prefixes on structure attributes

### DIFF
--- a/extension/DataGridUtils/Source/NET/ObtainMetadata.cs
+++ b/extension/DataGridUtils/Source/NET/ObtainMetadata.cs
@@ -91,6 +91,7 @@ namespace OutSystems.NssDataGridUtils {
 
             json.WriteStartObject();
 
+            // structures and its attributes
             var fields = objType.GetFields().Where(f => f.Name.StartsWith("ss"));
 
             foreach (var field in fields) {
@@ -105,6 +106,7 @@ namespace OutSystems.NssDataGridUtils {
                 }
             }
 
+            // entities and its attributes
             var properties = objType.GetProperties().Where(p => p.Name.StartsWith("ss"));
 
             foreach (var property in properties) {

--- a/extension/DataGridUtils/Source/NET/temp_ardoJSON.cs
+++ b/extension/DataGridUtils/Source/NET/temp_ardoJSON.cs
@@ -113,8 +113,12 @@ namespace OutSystems.NssDataGridUtils {
                 }
             } catch { }
 
+            // structures and its attributes
             foreach (var field in leClass.GetFields().Where(f => f.Name.StartsWith("ss"))) {
-                clearStart = field.Name.StartsWith("ssEN") || field.Name.StartsWith("ssST");
+                // we must check if field is Record or RecordList, if they are, we remove ssEN (ssEntity) or ssST (ssStructure); 
+                clearStart = typeof(IRecord).IsAssignableFrom(field.FieldType) || typeof(ISimpleRecord).IsAssignableFrom(field.FieldType) ? 
+                    field.Name.StartsWith("ssEN") || field.Name.StartsWith("ssST") :
+                    false;
                 //RGRIDT-364 - removing columns of the type BinaryData.
                 if (typeof(Byte[]).IsAssignableFrom(field.FieldType) == false) {
                     json.WritePropertyName(field.Name.Substring(clearStart ? 4 : 2));
@@ -122,6 +126,7 @@ namespace OutSystems.NssDataGridUtils {
                 }
             }
 
+            // entities and its attributes
             foreach (var property in leClass.GetProperties().Where(p => p.Name.StartsWith("ss"))) {
                 //RGRIDT-364 - removing columns of the type BinaryData.
                 if (typeof(Byte[]).IsAssignableFrom(property.PropertyType) == false) {


### PR DESCRIPTION
This PR fixes a wrong removal of prefixes on structure attributes. Example: If we had a Record List containing a Record that had attributes starting with "ST" or "EN", we were removing it.


