### PR TITLE
ROU-3762: Issues when using SetCellData with several Grids with columns with the same binding

### DIFF
--- a/src/OutSystems/GridAPI/Cell.ts
+++ b/src/OutSystems/GridAPI/Cell.ts
@@ -60,9 +60,10 @@ namespace OutSystems.GridAPI.Cells {
     ): void {
         Performance.SetMark('Cells.validateCell');
 
-        const column = ColumnManager.GetColumnById(columnID);
+        const grid = GridManager.GetGridById(gridID);
+        const column = grid.getColumn(columnID);
         if (column === undefined) return;
-        GridManager.GetGridById(gridID).features.validationMark.validateCell(
+        grid.features.validationMark.validateCell(
             rowIndex,
             column,
             triggerOnCellValueChange

--- a/src/OutSystems/GridAPI/Cell.ts
+++ b/src/OutSystems/GridAPI/Cell.ts
@@ -139,7 +139,7 @@ namespace OutSystems.GridAPI.Cells {
         }
 
         const grid = GridManager.GetGridById(gridID);
-        const column = ColumnManager.GetColumnById(columnID);
+        const column = ColumnManager.GetColumnById(columnID, gridID);
 
         if (column === undefined) {
             responseObj.isSuccess = false;

--- a/src/OutSystems/GridAPI/Cell.ts
+++ b/src/OutSystems/GridAPI/Cell.ts
@@ -139,7 +139,7 @@ namespace OutSystems.GridAPI.Cells {
         }
 
         const grid = GridManager.GetGridById(gridID);
-        const column = ColumnManager.GetColumnById(columnID, gridID);
+        const column = grid.getColumn(columnID);
 
         if (column === undefined) {
             responseObj.isSuccess = false;

--- a/src/OutSystems/GridAPI/ColumnManager.ts
+++ b/src/OutSystems/GridAPI/ColumnManager.ts
@@ -135,10 +135,17 @@ namespace OutSystems.GridAPI.ColumnManager {
      * @param columnID Column Id
      */
     export function GetColumnById(
-        columnID: string
+        columnID: string,
+        gridID?: string
     ): OSFramework.DataGrid.Column.IColumn {
         // we want to return the last column in our array that matches our predicate
-        return _.findLast(columnArr, (p) => p && p.equalsToID(columnID));
+        return _.findLast(
+            columnArr,
+            (p) =>
+                p &&
+                p.equalsToID(columnID) &&
+                (!!gridID ? p.grid.equalsToID(gridID) : true)
+        );
     }
 
     /**

--- a/src/OutSystems/GridAPI/ColumnManager.ts
+++ b/src/OutSystems/GridAPI/ColumnManager.ts
@@ -135,17 +135,10 @@ namespace OutSystems.GridAPI.ColumnManager {
      * @param columnID Column Id
      */
     export function GetColumnById(
-        columnID: string,
-        gridID?: string
+        columnID: string
     ): OSFramework.DataGrid.Column.IColumn {
         // we want to return the last column in our array that matches our predicate
-        return _.findLast(
-            columnArr,
-            (p) =>
-                p &&
-                p.equalsToID(columnID) &&
-                (!!gridID ? p.grid.equalsToID(gridID) : true)
-        );
+        return _.findLast(columnArr, (p) => p && p.equalsToID(columnID));
     }
 
     /**

--- a/src/OutSystems/GridAPI/Styling.ts
+++ b/src/OutSystems/GridAPI/Styling.ts
@@ -136,14 +136,13 @@ namespace OutSystems.GridAPI.Styling {
         }
 
         try {
-            const column = ColumnManager.GetColumnById(columnID);
+            const grid = GridManager.GetGridById(gridID);
+            const column = grid.getColumn(columnID);
 
             if (column !== undefined) {
                 const binding = column.config.binding;
 
-                GridManager.GetGridById(
-                    gridID
-                ).features.cellStyle.removeAllClasses(rowIndex, binding, true);
+                grid.features.cellStyle.removeAllClasses(rowIndex, binding, true);
             } else {
                 responseObj.isSuccess = false;
                 responseObj.message =

--- a/src/OutSystems/GridAPI/Styling.ts
+++ b/src/OutSystems/GridAPI/Styling.ts
@@ -142,7 +142,11 @@ namespace OutSystems.GridAPI.Styling {
             if (column !== undefined) {
                 const binding = column.config.binding;
 
-                grid.features.cellStyle.removeAllClasses(rowIndex, binding, true);
+                grid.features.cellStyle.removeAllClasses(
+                    rowIndex,
+                    binding,
+                    true
+                );
             } else {
                 responseObj.isSuccess = false;
                 responseObj.message =


### PR DESCRIPTION
This PR is for fiz the bug in SetCellData action

### What was happening
* SetCellData function was getting the wrong column reference when there was two grids with same columns on the page

### What was done
* Instead of using the ColumnManager.GetColumnById() method, now we use grid.getColumn()

### Checklist
* [x] tested locally
* [ ] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [x] requires new sample page in OutSystems (if so, provide a module with changes)

