### PR TITLE
ROU-3733 - [DataGrid] - Client actions that return the selection min and max value

### DIFF
--- a/src/OSFramework/DataGrid/Feature/ISelection.ts
+++ b/src/OSFramework/DataGrid/Feature/ISelection.ts
@@ -68,7 +68,10 @@ namespace OSFramework.DataGrid.Feature {
          * Returns the Data of the selected rows
          */
         getSelectedRowsData(): OSStructure.ReturnMessage;
-
+        /**
+         * Returns the maximum or minimum value of the grid selected cells.
+         */
+        getSelectionMaxMin(isMax: boolean): OSStructure.ReturnMessage;
         /**
          * Checks if there is any checked row on the grid
          */

--- a/src/OutSystems/GridAPI/Selection.ts
+++ b/src/OutSystems/GridAPI/Selection.ts
@@ -74,6 +74,38 @@ namespace OutSystems.GridAPI.Selection {
         return JSON.stringify(grid.features.selection.getSelectedRowsData());
     }
 
+    export function GetSelectionMax(gridID: string): string {
+        Performance.SetMark('Selection.GetSelectionMax');
+
+        if (!OSFramework.DataGrid.Helper.IsGridReady(gridID)) return '[]';
+        const grid = GridManager.GetGridById(gridID);
+
+        Performance.SetMark('Selection.GetSelectionMax-end');
+        Performance.GetMeasure(
+            '@datagrid-Selection.GetSelectionMax',
+            'Selection.GetSelectionMax',
+            'Selection.GetSelectionMax-end'
+        );
+        return JSON.stringify(grid.features.selection.getSelectionMaxMin(true));
+    }
+
+    export function GetSelectionMin(gridID: string): string {
+        Performance.SetMark('Selection.GetSelectionMin');
+
+        if (!OSFramework.DataGrid.Helper.IsGridReady(gridID)) return '[]';
+        const grid = GridManager.GetGridById(gridID);
+
+        Performance.SetMark('Selection.GetSelectionMin-end');
+        Performance.GetMeasure(
+            '@datagrid-Selection.GetSelectionMin',
+            'Selection.GetSelectionMin',
+            'Selection.GetSelectionMin-end'
+        );
+        return JSON.stringify(
+            grid.features.selection.getSelectionMaxMin(false)
+        );
+    }
+
     export function HasSelectedRows(gridID: string): string {
         Performance.SetMark('Selection.HasSelectedRows');
 

--- a/src/Providers/DataGrid/Wijmo/Features/Selection.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Selection.ts
@@ -510,6 +510,49 @@ namespace Providers.DataGrid.Wijmo.Feature {
             }
         }
 
+        public getSelectionMaxMin(
+            isMax: boolean
+        ): OSFramework.DataGrid.OSStructure.ReturnMessage {
+            let _max = -Infinity;
+            let _min = Infinity;
+            const _grid = this._grid;
+            const _items = this.getAllSelectionsData().value;
+            try {
+                for (let i = 0; i < _items.length; i++) {
+                    _items[i].selected.forEach((element) => {
+                        const columnType = _grid.getColumn(
+                            element.binding
+                        ).columnType;
+                        if (
+                            columnType ===
+                                OSFramework.DataGrid.Enum.ColumnType.Number ||
+                            columnType ===
+                                OSFramework.DataGrid.Enum.ColumnType.Currency ||
+                            columnType ===
+                                OSFramework.DataGrid.Enum.ColumnType.Calculated
+                        ) {
+                            _min = Math.min(_min, element.value);
+                            _max = Math.max(_max, element.value);
+                        }
+                    });
+                }
+                return {
+                    value: isMax ? _max : _min,
+                    isSuccess: true,
+                    message:
+                        OSFramework.DataGrid.Enum.ErrorMessages.SuccessMessage,
+                    code: OSFramework.DataGrid.Enum.ErrorCodes.GRID_SUCCESS
+                };
+            } catch (error) {
+                return {
+                    value: null,
+                    isSuccess: false,
+                    message: error.message
+                    //TODO code: OSFramework.DataGrid.Enum.ErrorCodes.API_FailedGetSelectionAverage
+                };
+            }
+        }
+
         public hasCheckedRows(): boolean {
             return this.getCheckedRowsData().value.length > 0;
         }


### PR DESCRIPTION
This PR is to add new APIs that allows the user to get the max and min of a cell selection.

### What was done
* Create methods that get the value of number, currency, and calculated cells selected and calculate the min or max of it.

### Test Steps
1. Run the APIs after a selection;
2. Check if the value is the expected;

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems
* [ ] requires new sample page in OutSystems

