### PR TITLE
ROU-3885: Fix getTime bug when the date is in string format

### DIFF
--- a/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
@@ -119,12 +119,7 @@ namespace OSFramework.DataGrid.Grid {
                     (columnsType.get(key) === 'Date' || dateColumns.has(key)) &&
                     object[key]
                 ) {
-                    const dt = object[key] as Date;
-                    object[key] = new Date(
-                        dt.getTime() - dt.getTimezoneOffset() * 60000
-                    )
-                        .toISOString()
-                        .substring(0, 10);
+                    object[key] = OSFramework.DataGrid.Helper.ToOSDate(object[key])
                 }
             });
         };

--- a/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
@@ -119,7 +119,7 @@ namespace OSFramework.DataGrid.Grid {
                     (columnsType.get(key) === 'Date' || dateColumns.has(key)) &&
                     object[key]
                 ) {
-                    object[key] = OSFramework.DataGrid.Helper.ToOSDate(object[key])
+                    object[key] = DataGrid.Helper.ToOSDate(object[key]);
                 }
             });
         };

--- a/src/OSFramework/DataGrid/Helper/JSONParser.ts
+++ b/src/OSFramework/DataGrid/Helper/JSONParser.ts
@@ -2,11 +2,14 @@
 namespace OSFramework.DataGrid.Helper {
     /**
      * Formats the date into an ISOString and then returns it with the format 'YYY-MM-DDT00:00:000Z'.
-     * @param data Data to format
+     * @param date Date to format
      * @returns Date specified in the ISOString format.
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     export function ToOSDatetime(date: Date): string {
+        if( typeof(date) === 'string'){
+            date = new Date(date)
+        }
         return date.toISOString();
     }
 
@@ -17,6 +20,9 @@ namespace OSFramework.DataGrid.Helper {
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     export function ToOSDate(date: Date): string {
+        if( typeof(date) === 'string'){
+            date = new Date(date)
+        }
         return new Date(date.getTime() - date.getTimezoneOffset() * 60000)
             .toISOString()
             .substr(0, 10);

--- a/src/OSFramework/DataGrid/Helper/JSONParser.ts
+++ b/src/OSFramework/DataGrid/Helper/JSONParser.ts
@@ -7,8 +7,8 @@ namespace OSFramework.DataGrid.Helper {
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     export function ToOSDatetime(date: Date): string {
-        if( typeof(date) === 'string'){
-            date = new Date(date)
+        if (typeof date === 'string') {
+            date = new Date(date);
         }
         return date.toISOString();
     }
@@ -20,8 +20,8 @@ namespace OSFramework.DataGrid.Helper {
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     export function ToOSDate(date: Date): string {
-        if( typeof(date) === 'string'){
-            date = new Date(date)
+        if (typeof date === 'string') {
+            date = new Date(date);
         }
         return new Date(date.getTime() - date.getTimezoneOffset() * 60000)
             .toISOString()


### PR DESCRIPTION
This PR is for fix the bug when changing the value of a Date Column that initially has a DateTime type data assigned to it. Same issue was also happening when calling GetChangedRosw action.

### What was happening
* When passing DateTime attributes in a Date column and vice versa, we were getting the error `date.getTime() is not a function`.
* The GetChangedRows action was not returning the changed rows when the Datetime column with a date attribute gad it values changed.

### What was done
* Inserted an assertion that check if the value that comes from a Date and DateTime columns is a string. If it is, so we convert it to a Date format.

### Test Steps
1. Go to test page.
2. Open the Dev Tools console tab
3. Change the date of the first column
4. Check that no error has appeared in the console
5. Click in GetChangedRows button
6. Check if the new value for that columns was the expected
7. Repeat it for the other columns
Note: GetChangedRows returns the server Date or DateTime.



### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

