### PR TITLE
ROU-3891: Decimal places not working properly on calculated columns

### DIFF
--- a/src/OSFramework/DataGrid/Configuration/Column/ColumnConfigAdditional.ts
+++ b/src/OSFramework/DataGrid/Configuration/Column/ColumnConfigAdditional.ts
@@ -6,6 +6,7 @@ namespace OSFramework.DataGrid.Configuration.Column {
      * Defines the configuration for Calculated Columns
      */
     export class ColumnConfigAdditional extends ColumnConfigConditionalFormat {
+        public decimalPlaces: number;
         public formula: OSStructure.Formula;
 
         constructor(
@@ -13,6 +14,7 @@ namespace OSFramework.DataGrid.Configuration.Column {
             extraConfig: DataGrid.Types.ICalculatedColumnExtraConfigs
         ) {
             super(config, extraConfig);
+            this.decimalPlaces = extraConfig.decimalPlaces;
             this.formula = extraConfig.formula;
         }
     }

--- a/src/OSFramework/DataGrid/Configuration/Column/ColumnConfigAdditional.ts
+++ b/src/OSFramework/DataGrid/Configuration/Column/ColumnConfigAdditional.ts
@@ -8,6 +8,7 @@ namespace OSFramework.DataGrid.Configuration.Column {
     export class ColumnConfigAdditional extends ColumnConfigConditionalFormat {
         public decimalPlaces: number;
         public formula: OSStructure.Formula;
+        public hasThousandSeparator: boolean;
 
         constructor(
             config: DataGrid.Types.IColumnConfigs,
@@ -16,6 +17,7 @@ namespace OSFramework.DataGrid.Configuration.Column {
             super(config, extraConfig);
             this.decimalPlaces = extraConfig.decimalPlaces;
             this.formula = extraConfig.formula;
+            this.hasThousandSeparator = extraConfig.hasThousandSeparator;
         }
     }
 }

--- a/src/OSFramework/DataGrid/Types/index.ts
+++ b/src/OSFramework/DataGrid/Types/index.ts
@@ -218,6 +218,7 @@ namespace OSFramework.DataGrid.Types {
      * Calculated column extra configs
      */
     export interface ICalculatedColumnExtraConfigs extends ICommonExtraConfigs {
+        decimalPlaces: number;
         formula: DataGrid.OSStructure.Formula;
     }
 }

--- a/src/OSFramework/DataGrid/Types/index.ts
+++ b/src/OSFramework/DataGrid/Types/index.ts
@@ -220,5 +220,6 @@ namespace OSFramework.DataGrid.Types {
     export interface ICalculatedColumnExtraConfigs extends ICommonExtraConfigs {
         decimalPlaces: number;
         formula: DataGrid.OSStructure.Formula;
+        hasThousandSeparator: boolean;
     }
 }

--- a/src/Providers/DataGrid/Wijmo/Columns/AbstractProviderColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/AbstractProviderColumn.ts
@@ -10,7 +10,9 @@ namespace Providers.DataGrid.Wijmo.Column {
         private _provider: wijmo.grid.ColumnGroup;
 
         public get columnEvents(): OSFramework.DataGrid.Event.Column.ColumnEventsManager {
-            throw `The column ${this.columnType.toString()} does not support events`;
+            throw new Error(
+                `The column ${this.columnType.toString()} does not support events`
+            );
         }
 
         /** Checks if the column has associated events */

--- a/src/Providers/DataGrid/Wijmo/Columns/CalculatedColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/CalculatedColumn.ts
@@ -50,9 +50,6 @@ namespace Providers.DataGrid.Wijmo.Column {
 
         /**
          * Makes the provider string format based on decimal places and thousands separator
-         *
-         * @param decimalPlaces Precision for numeric values
-         * @param hasThousandSeparator Boolean indicating if it must have thousand sepataros
          */
         private _setFormat(): void {
             // if format starts with n, the number will have thousand separator

--- a/src/Providers/DataGrid/Wijmo/Columns/CalculatedColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/CalculatedColumn.ts
@@ -30,7 +30,16 @@ namespace Providers.DataGrid.Wijmo.Column {
         }
 
         // by default, we want numbers to have thousand separator
-        private _setEditorFormat(decimalPlaces): void {
+        private _setEditorFormat(
+            decimalPlaces,
+            hasThousandSeparator = true
+        ): void {
+            // if format starts with n, the number will have thousand separator
+            // if starts with f, it won't
+            const format = hasThousandSeparator ? 'n' : 'f';
+
+            this.config.format = `${format} ${decimalPlaces}`;
+
             this.config.format = `n ${decimalPlaces}`;
         }
 
@@ -40,7 +49,10 @@ namespace Providers.DataGrid.Wijmo.Column {
          * @param decimalPlaces Precision for numeric values
          * @param args Used for extension by inherited classes
          */
-        protected _setFormat(decimalPlaces: number): void {
+        protected _setFormat(
+            decimalPlaces: number,
+            hasThousandSeparator = true
+        ): void {
             if (decimalPlaces > 11 || decimalPlaces < 0) {
                 throw new Error(
                     `Invalid parameter decimal places configuration for column "${this.provider.header}".\nAvailable range for decimal places 0 to 11.`
@@ -55,7 +67,7 @@ namespace Providers.DataGrid.Wijmo.Column {
                               .decimals;
             }
 
-            this._setEditorFormat(decimalPlaces);
+            this._setEditorFormat(decimalPlaces, hasThousandSeparator);
         }
         /** Returns all the events associated to the column */
         public get columnEvents(): OSFramework.DataGrid.Event.Column.ColumnEventsManager {
@@ -72,7 +84,10 @@ namespace Providers.DataGrid.Wijmo.Column {
 
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         public build(): any {
-            this._setFormat(this.config.decimalPlaces);
+            this._setFormat(
+                this.config.decimalPlaces,
+                this.config.hasThousandSeparator
+            );
             super.build();
             this.grid.features.filter.deactivate(this.uniqueId);
             this.grid.features.calculatedField.addFormula(
@@ -88,6 +103,11 @@ namespace Providers.DataGrid.Wijmo.Column {
                 case OSFramework.DataGrid.OSStructure.ColumnProperties
                     .DecimalPlaces:
                     this._setFormat(propertyValue);
+                    this.applyConfigs();
+                    break;
+                case OSFramework.DataGrid.OSStructure.ColumnProperties
+                    .HasThousandSeparator:
+                    this._setFormat(this.config.decimalPlaces, propertyValue);
                     this.applyConfigs();
                     break;
                 default:

--- a/src/Providers/DataGrid/Wijmo/Columns/Factory.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/Factory.ts
@@ -69,7 +69,7 @@ namespace Providers.DataGrid.Wijmo.Column {
                         grid,
                         columnID,
                         configs,
-                        extraConfigs
+                        extraConfigs as OSFramework.DataGrid.Types.ICalculatedColumnExtraConfigs
                     );
                 case OSFramework.DataGrid.Enum.ColumnType.Text:
                     return new TextColumn(
@@ -79,7 +79,9 @@ namespace Providers.DataGrid.Wijmo.Column {
                         extraConfigs as OSFramework.DataGrid.Types.ITextColumnExtraConfigs
                     );
                 default:
-                    throw `There is no factory for this type of column (${type})`;
+                    throw new Error(
+                        `There is no factory for this type of column (${type})`
+                    );
             }
         }
     }


### PR DESCRIPTION
This PR is for add to Calculated Columns the functionality to handle with DecimalPlaces and HasThousandsSeparator parameters.

### What was done
* Added new the parameters
* Added the logic to handle them on build
* Added the logic to handle their change in OnParameterChange

### Test Steps
1. Go to the test page
2. Set a valid value (0 to 11) to Decimal Places
3. Click in "Update Decimal Places"
Expected: The values in the calculated columns are updated to the new decimal places number.

1. Go to the test page
2. Switch the "Add thousands separator" switch button
Expected: The values in the calculated columns react adding or removing the thousands separator.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [x] requires new sample page in OutSystems (if so, provide a module with changes)

