### PR TITLE
ROU-3936: Fix GetChangedLines not working when not on the first page

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -35,16 +35,17 @@ namespace Providers.DataGrid.Wijmo.Feature {
         /**
          * Handler for the CellEditEnding.
          */
-        private _cellEditBeforeEndingHandler( s: wijmo.grid.FlexGrid,
+        private _cellEditBeforeEndingHandler(
+            s: wijmo.grid.FlexGrid,
             e: wijmo.grid.CellRangeEventArgs
         ): void {
             // get old and new values
-             let oldVal = s.getCellData(e.row, e.col, false) ?? '',
-                 newVal = s.activeEditor.value ?? '';
-           
-             // cancel edits if oldVal is equals to newVal
-             e.cancel = oldVal === newVal;
-       }
+            const oldVal = s.getCellData(e.row, e.col, false) ?? '';
+            const newVal = s.activeEditor.value ?? '';
+
+            // cancel edits if oldVal is equals to newVal
+            e.cancel = oldVal === newVal;
+        }
 
         /**
          * Handler for the CellEditEnded.

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -33,6 +33,20 @@ namespace Providers.DataGrid.Wijmo.Feature {
         // }
 
         /**
+         * Handler for the CellEditEnding.
+         */
+        private _cellEditBeforeEndingHandler( s: wijmo.grid.FlexGrid,
+            e: wijmo.grid.CellRangeEventArgs
+        ): void {
+            // get old and new values
+             let oldVal = s.getCellData(e.row, e.col, false) ?? '',
+                 newVal = s.activeEditor.value ?? '';
+           
+             // cancel edits if oldVal is equals to newVal
+             e.cancel = oldVal === newVal;
+       }
+
+        /**
          * Handler for the CellEditEnded.
          */
         private _cellEditHandler(
@@ -402,6 +416,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
         }
 
         public build(): void {
+            this._grid.provider.cellEditEnding.addHandler(
+                this._cellEditBeforeEndingHandler.bind(this)
+            );
             this._grid.provider.cellEditEnded.addHandler(
                 this._cellEditHandler.bind(this)
             );

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -41,7 +41,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
         ): void {
             // get old and new values
             const oldVal = s.getCellData(e.row, e.col, false) ?? '';
-            const newVal = s.activeEditor.value ?? '';
+            const newVal = s.activeEditor?.value ?? '';
 
             // cancel edits if oldVal is equals to newVal
             e.cancel = oldVal === newVal;

--- a/src/Providers/DataGrid/Wijmo/Grid/ProviderDataSource.ts
+++ b/src/Providers/DataGrid/Wijmo/Grid/ProviderDataSource.ts
@@ -47,13 +47,12 @@ namespace Providers.DataGrid.Wijmo.Grid {
                 );
             }
 
-            if (
-                itemsSource.itemsEdited.length > 0
-            ) {
+            if (itemsSource.itemsEdited.length > 0) {
                 //const dirtyEditedItems = this._getDirtyEditedItems();
                 changes.hasChanges = true;
-                changes.editedLinesJSON =
-                    this._getChangesString(itemsSource.itemsEdited);
+                changes.editedLinesJSON = this._getChangesString(
+                    itemsSource.itemsEdited
+                );
             }
 
             if (itemsSource.itemsRemoved.length > 0) {

--- a/src/Providers/DataGrid/Wijmo/Grid/ProviderDataSource.ts
+++ b/src/Providers/DataGrid/Wijmo/Grid/ProviderDataSource.ts
@@ -7,7 +7,7 @@ namespace Providers.DataGrid.Wijmo.Grid {
         private _getDirtyEditedItems() {
             const itemsSource = this._provider;
             return itemsSource.itemsEdited.filter((editedItem) => {
-                const rowIndex = itemsSource.sourceCollection.findIndex(
+                const rowIndex = itemsSource.items.findIndex(
                     (item) => item === editedItem
                 );
 

--- a/src/Providers/DataGrid/Wijmo/Grid/ProviderDataSource.ts
+++ b/src/Providers/DataGrid/Wijmo/Grid/ProviderDataSource.ts
@@ -7,7 +7,7 @@ namespace Providers.DataGrid.Wijmo.Grid {
         private _getDirtyEditedItems() {
             const itemsSource = this._provider;
             return itemsSource.itemsEdited.filter((editedItem) => {
-                const rowIndex = itemsSource.items.findIndex(
+                const rowIndex = itemsSource.sourceCollection.findIndex(
                     (item) => item === editedItem
                 );
 
@@ -48,13 +48,12 @@ namespace Providers.DataGrid.Wijmo.Grid {
             }
 
             if (
-                itemsSource.itemsEdited.length > 0 &&
-                this.parentGrid.features.dirtyMark.isGridDirty
+                itemsSource.itemsEdited.length > 0
             ) {
-                const dirtyEditedItems = this._getDirtyEditedItems();
+                //const dirtyEditedItems = this._getDirtyEditedItems();
                 changes.hasChanges = true;
                 changes.editedLinesJSON =
-                    this._getChangesString(dirtyEditedItems);
+                    this._getChangesString(itemsSource.itemsEdited);
             }
 
             if (itemsSource.itemsRemoved.length > 0) {

--- a/src/Providers/DataGrid/Wijmo/Grid/ProviderDataSource.ts
+++ b/src/Providers/DataGrid/Wijmo/Grid/ProviderDataSource.ts
@@ -48,7 +48,6 @@ namespace Providers.DataGrid.Wijmo.Grid {
             }
 
             if (itemsSource.itemsEdited.length > 0) {
-                //const dirtyEditedItems = this._getDirtyEditedItems();
                 changes.hasChanges = true;
                 changes.editedLinesJSON = this._getChangesString(
                     itemsSource.itemsEdited


### PR DESCRIPTION
This PR is for fix the issue with the GetChangedLines returning an empty array when not in the first page, even with edited lines in the page, and when filter and sort were applied.

### What was happening
* In src\Providers\DataGrid\Wijmo\Grid\ProviderDataSource.ts:
   * In _getDirtyEditedItems():
       * itemsSource.sourceCollection.findIndex() returns the index based on all data, not only in the current view.
       * isRowDirty() method was returning false when the rowIndex >= number of rows in the view, because the _hasMetadata inside the _isDirtyRow() method only validates the metadata of the rows in the current view.

### What was done
* Because of other issues found during the development of this task, it was necessary to rollback a previous fix related to GetChangedLines (ROU-3592). As a consequence, the bug that the fix solved, is happening again but in a different way.
  * In ProviderDataSource.ts:
     * In getChanges method:
       * The editedLinesJSON is now using the itemsource.itemsEdited from Wijmo again.
       * The isGridDirty validation was removed, so the GetChangedLines return the editedLines even when the view is not dirty.
  * In ValidationMark.ts:
    * In build method:
      * Added new handler to the cellEditEnding event.
      * The handler prevents changes from null to "" to be considered an effective change.
      * It partially fix the ROU-3592 (it still occurs in a very specific case related to calculated columns).
 
### Test Steps
- Test 1:
  1. Go to APIData test page.
  2. Edit any row in the second page of the grid.
  3. Go back to the first page.
  4. Click on GetChangedLines button.
  Expected: The displayed message shows the edited lines.
  5. Edit any row in the first page of the grid.
  6. Click on GetChangedLines button.
  Expected: The displayed message shows all the edited lines.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

