### PR TITLE
ROU-3950: Investigate the reason why the columns OnCellValueChange is not triggered with the original value

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
@@ -141,7 +141,10 @@ namespace Providers.DataGrid.Wijmo.Column {
             newValue: any
         ): void {
             // only set to blank if there is a different value
-            if (oldValue !== newValue) {
+            if (
+                oldValue !== newValue &&
+                parseFloat(oldValue) !== parseFloat(newValue)
+            ) {
                 const column = this.grid.getColumn(columnID);
                 const currentValue = this.grid.provider.getCellData(
                     rowNumber,

--- a/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
@@ -143,7 +143,7 @@ namespace Providers.DataGrid.Wijmo.Column {
             // only set to blank if there is a different value
             if (
                 oldValue !== newValue &&
-                parseFloat(oldValue) !== parseFloat(newValue)
+                oldValue.toString() !== newValue.toString()
             ) {
                 const column = this.grid.getColumn(columnID);
                 const currentValue = this.grid.provider.getCellData(

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -54,7 +54,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
             //For dropdowns we also need to check if the number in string is not equal to the number itself
             if (
                 (oldValue !== newValue &&
-                    parseFloat(oldValue) !== parseFloat(newValue)) ||
+                    oldValue.toString() !== newValue.toString()) ||
                 (oldValue === newValue &&
                     this._grid.features.dirtyMark.isGridDirty)
             ) {

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -34,7 +34,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
         /**
          * Handler for the CellEditEnding.
-         * It checks if the cell value effectively changed 
+         * It checks if the cell value effectively changed
          * For this purpose, here we consider null == undefined == ''
          * Bug: it does not work for checkboxes, since the activeEditor.value is always "on"
          */

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -50,7 +50,14 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 e.row,
                 column.binding
             );
-            if (oldValue !== newValue) {
+            //Trigger this only if is not the same value or is the initial after changes
+            //For dropdowns we also need to check if the number in string is not equal to the number itself
+            if (
+                (oldValue !== newValue &&
+                    parseFloat(oldValue) !== parseFloat(newValue)) ||
+                (oldValue === newValue &&
+                    this._grid.features.dirtyMark.isGridDirty)
+            ) {
                 this._triggerEventsFromColumn(
                     e.row,
                     OSColumn.uniqueId,


### PR DESCRIPTION
This PR is for fix the OnCellValueChange is not triggering with the original value.

### What was happening
* When changing the cell value to a different value and then returning to its original value, the OnCellValueChange is not triggered.
* When opening and closing the dropdown, it mark the cell as changed and it shouldn’t.
* When erasing the cell value using the delete key, the OnCellValueChange was not being triggered

### What was done
* In _cellEditBeforeEndingHandler in ValidationMark.ts, added new validations to check if the delete key was pressed and get the right currentValue.
* Since we are already validating if the value changed or not, we can use the `e.cancel` to trigger or nor the OnCellValueChange event in _cellEditHandler()

### Test Steps

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [x] requires new sample page in OutSystems (if so, provide a module with changes)

