### PR TITLE
ROU-3994: Dirty mark appear when the dropdown cell returns to its original value

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/DirtyMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/DirtyMark.ts
@@ -26,6 +26,22 @@ namespace Providers.DataGrid.Wijmo.Feature {
             this.saveOriginalValue(e.row, e.col);
         }
 
+        // check if values are equal.
+        // since undefined is not equal to null or an empty string, we explicity say we want them to be considered equal
+        private _isOriginalValue(originalValue: any, cellValue: any): boolean {
+            return !_.isEqualWith(originalValue, cellValue, () => {
+                if (
+                    (originalValue === undefined &&
+                        (cellValue === undefined ||
+                            cellValue === null ||
+                            cellValue === '')) ||
+                    originalValue?.toString() === cellValue?.toString()
+                ) {
+                    return true;
+                }
+            });
+        }
+
         private _formatItems(
             _grid: wijmo.grid.FlexGrid,
             e: wijmo.grid.FormatItemEventArgs
@@ -63,18 +79,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 if (metadata.originalValues.has(binding)) {
                     const originalValue = metadata.originalValues.get(binding);
 
-                    // check if values are equal.
-                    // since undefined is not equal to null or an empty string, we explicity say we want them to be considered equal
-                    return !_.isEqualWith(originalValue, cellValue, () => {
-                        if (
-                            originalValue === undefined &&
-                            (cellValue === undefined ||
-                                cellValue === null ||
-                                cellValue === '')
-                        ) {
-                            return true;
-                        }
-                    });
+                    return this._isOriginalValue(originalValue, cellValue);
                 }
             }
             return false;
@@ -95,18 +100,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                         false
                     );
 
-                    // check if values are equal.
-                    // since undefined is not equal to null or an empty string, we explicity say we want them to be considered equal
-                    return !_.isEqualWith(originalValue, cellValue, () => {
-                        if (
-                            originalValue === undefined &&
-                            (cellValue === undefined ||
-                                cellValue === null ||
-                                cellValue === '')
-                        ) {
-                            return true;
-                        }
-                    });
+                    return this._isOriginalValue(originalValue, cellValue);
                 });
                 return hasDirtyMarkCell;
             }

--- a/src/Providers/DataGrid/Wijmo/Features/DirtyMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/DirtyMark.ts
@@ -26,22 +26,6 @@ namespace Providers.DataGrid.Wijmo.Feature {
             this.saveOriginalValue(e.row, e.col);
         }
 
-        // check if values are equal.
-        // since undefined is not equal to null or an empty string, we explicity say we want them to be considered equal
-        private _isOriginalValue(originalValue: any, cellValue: any): boolean {
-            return !_.isEqualWith(originalValue, cellValue, () => {
-                if (
-                    (originalValue === undefined &&
-                        (cellValue === undefined ||
-                            cellValue === null ||
-                            cellValue === '')) ||
-                    originalValue?.toString() === cellValue?.toString()
-                ) {
-                    return true;
-                }
-            });
-        }
-
         private _formatItems(
             _grid: wijmo.grid.FlexGrid,
             e: wijmo.grid.FormatItemEventArgs
@@ -116,6 +100,25 @@ namespace Providers.DataGrid.Wijmo.Feature {
             return this._grid.provider.itemsSource.sourceCollection.some(
                 (_row, index) => this._isDirtyRow(index)
             );
+        }
+
+        // check if values are equal.
+        // since undefined is not equal to null or an empty string, we explicity say we want them to be considered equal
+        private _isOriginalValue(
+            originalValue: string | number,
+            cellValue: string | number
+        ): boolean {
+            return !_.isEqualWith(originalValue, cellValue, () => {
+                if (
+                    (originalValue === undefined &&
+                        (cellValue === undefined ||
+                            cellValue === null ||
+                            cellValue === '')) ||
+                    originalValue?.toString() === cellValue?.toString()
+                ) {
+                    return true;
+                }
+            });
         }
 
         public build(): void {


### PR DESCRIPTION
This PR is for fix the dirty mark appearing when the dropdown cell returns to its original value. 

### What was done
* Added a validation for when the values compared are from different types (int and string).

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

