### PR TITLE
ROU-4011: Fix parent dropdown not erasing the child when returning to its original value

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
@@ -181,10 +181,10 @@ namespace Providers.DataGrid.Wijmo.Column {
                         (action: GridEditAction) =>
                             action.col === this.provider.index &&
                             action.row === rowNumber
-                    );
+                    ) ?? false;
 
                 // only add child undo action if it doesn't already exist. we don't want duplicated actions
-                if (!existingEditActionForColRow) {
+                if (existingEditActionForColRow === false) {
                     // add new child action into existing parent action in order
                     existingUndoAction.addChildAction(
                         new GridEditAction(


### PR DESCRIPTION
This PR is for fix parent dropdown not erasing the child when returning to its original value

### What was happening
* The parent dropdown handler was not erasing the child value when oldValue === newValue

### What was done
* Removed the code that erases the dropdown child cell from the if that verifies if the oldValue is different than the newValue.
* Now it also erases the values when the oldValue is equal to the newValue.

### Test Steps
1. Go to the DropdownDependency test page 
2. Change the parent dropdown of the first row to different value
3. Change the child dropdown of the first row to a different value
4. Change the parent dropdown of the first row to the original value
5. Check if the child dropdown of the first row is empty, has a dirty mark and is invalid.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

