### PR TITLE
ROU-12218: Improved touch handling for the Data Grid with frozen columns on mobile devices

### DIFF
--- a/styles/Grid.css
+++ b/styles/Grid.css
@@ -302,6 +302,13 @@
     filter: drop-shadow(10px 1px 5px rgba(1, 1, 1, 0.08));
 }
 
+/*Overrides the clones frozen cells to prevent columns/rows swiping*/
+.ios .wj-flexgrid .wj-frozen-clone .wj-cell,
+.android .wj-flexgrid .wj-frozen-clone .wj-cell
+ {
+    pointer-events: none;
+}
+
 /* Overrides scenarios where we have for instance elements like dropdowns on top of it when having frozen columns*/
 div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
     z-index: 3 !important;


### PR DESCRIPTION
This PR is to improve touch handling for the Data Grid with frozen columns on mobile devices.
While this fix provides a smoother experience, please note that the Data Grid is not officially targeted for mobile platforms.

### What was happening
* When using the Data Grid component with frozen columns using FreezeColumns, the table cannot be scrolled by dragging up or down.
* This only happened when on mobile devices, ie, on a native web app.

### What was done
* We managed to get a quick answer from Mescius and they were able to find the issue with frozen columns/rows swiping.
They also mentioned that the following workaround is effective for this issue, which we confirmed:
```css
.wj-flexgrid .wj-frozen-clone .wj-cell {
pointer-events: none;
}
``` 
* In this PR we'll narrow down the impact by applying it only for the class `.ios` and `.android`.


### Test Steps
1. Open app with a Data Grid with frozen columns on a mobile device
2. Swipe up/down on frozen columns
3. Swipe up/down + left/rigth on the other columns
4. Check that its working better


### Screenshots

- Before:
https://github.com/user-attachments/assets/bdc6c3b3-f763-4f02-9d2c-50a14998720e

- After improvement:
https://github.com/user-attachments/assets/46d7b433-47a3-4c41-9049-7445de376bbc


### Checklist
* [X] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

