### PR TITLE
ROU-12172: Improve filter dropdown menu arrow interaction

### DIFF
--- a/styles/Grid.css
+++ b/styles/Grid.css
@@ -713,7 +713,17 @@ div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
     .wj-input-group
     .wj-form-control {
     padding: var(--datagrid-filter-input-padding);
+    width: 100%;
 }
+
+.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor
+    .wj-control
+    .wj-input-group
+    [wj-part=btn] {
+    min-height: 0;
+    height: auto;
+}
+
 
 .wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor
     .wj-control


### PR DESCRIPTION
This PR is for fixing the arrow interaction of the dropdown menu inside the filter by condition

### What was happening
* On some screen sizes, the dropdown menu arrow was not clickable in all the pretended space
<img width="267" height="179" alt="image" src="https://github.com/user-attachments/assets/a7a3d694-357b-4d2e-afd1-370e5787588f" />

### What was done
* guarantee filter input and filter button occupy the space available;

### Test Steps
1. Check a column filter, where is possible to filter by condition;
2. Check if the pointer changes to clickable in all the available height
3. Check if the pointer changes to clickable from the arrow to the right edge;

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

