### PR TITLE
ROU-12216: Issue when reordering a column group

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/GridReorder.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/GridReorder.ts
@@ -29,7 +29,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			const col = e.getColumn(true);
 			const column = this._grid.getColumn(col.binding);
 			if (
-				column.hasEvents &&
+				column && column.hasEvents &&
 				column.columnEvents.events.has(OSFramework.DataGrid.Event.Column.ColumnEventType.OnColumnReorder)
 			) {
 				column.columnEvents.trigger(OSFramework.DataGrid.Event.Column.ColumnEventType.OnColumnReorder, null);


### PR DESCRIPTION
This PR is for fix the issue when reordering column group and performing undo action.

### What was happening
- When an edition was done in a Column group and the column was reordered, the undo action was not moving the column back to its previous position.
- This was happening because an error was throw when the column group was reordered, what prevent the action to being registered in the undo stack.

### What was done
* Added a validation in the `_draggedColumnHandler` to check if the column is defined before trying to execute the column events.

### Screenshots
Before fix:
![reorderandundo-beforefix](https://github.com/user-attachments/assets/7cb3e955-089a-481a-a816-de0f01bbb5a1)

After fix:
![reorderandundo](https://github.com/user-attachments/assets/6c54dd5c-5838-47b8-9de7-bc86a1f73cbd)



### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

