### PR TITLE
ROU-12231: Fix Data APIs returning incorrect values on Grid with GroupColumn

### DIFF
--- a/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
@@ -271,7 +271,7 @@ namespace OSFramework.DataGrid.Grid {
 
 			columns
 				.map((col) => col.config.binding)
-				.filter((colBinding) => !colBinding.startsWith('$')) // remove Action/Calculated columns
+				.filter((colBinding) => !colBinding.startsWith('$') && colBinding) // remove Action/Calculated columns
 				.forEach((colBinding) => this._createObjectFromString(obj, colBinding));
 			return obj;
 		}

--- a/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
@@ -271,7 +271,7 @@ namespace OSFramework.DataGrid.Grid {
 
 			columns
 				.map((col) => col.config.binding)
-				.filter((colBinding) => !colBinding.startsWith('$') && colBinding) // remove Action/Calculated columns and the ones that don't have bindings as Group columns
+				.filter((colBinding) => colBinding && !colBinding.startsWith('$')) // remove Action/Calculated columns and the ones that don't have bindings as Group columns
 				.forEach((colBinding) => this._createObjectFromString(obj, colBinding));
 			return obj;
 		}

--- a/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
@@ -271,7 +271,7 @@ namespace OSFramework.DataGrid.Grid {
 
 			columns
 				.map((col) => col.config.binding)
-				.filter((colBinding) => !colBinding.startsWith('$') && colBinding) // remove Action/Calculated columns
+				.filter((colBinding) => !colBinding.startsWith('$') && colBinding) // remove Action/Calculated columns and the ones that don't have bindings as Group columns
 				.forEach((colBinding) => this._createObjectFromString(obj, colBinding));
 			return obj;
 		}


### PR DESCRIPTION
This pull request makes a small adjustment to the filtering logic for column bindings in the `AbstractGrid` class. The update ensures that columns without bindings (such as Group columns) are excluded, in addition to Action/Calculated columns.

### What was happening
* When the ArrangeData action is not being used and a new Row is added to a Grid that implement a Group Column, the new item added was not being sanitized properly causing inconsistent results being returned by some Data APIs.

### What was done
* Improved the `.filter()` condition in the method to exclude columns that either start with '$' or do not have a binding, preventing Group columns from being processed. 

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

