### PR TITLE
ROU-12236: Automatic Scrolling to DataGrid on Initial Grouping or Filtering Using Client Actions

### DIFF
--- a/src/OSFramework/DataGrid/Feature/IColumnFilter.ts
+++ b/src/OSFramework/DataGrid/Feature/IColumnFilter.ts
@@ -7,10 +7,10 @@ namespace OSFramework.DataGrid.Feature {
 			IView {
 		isGridFiltered: boolean;
 		activate(columnID: string): void;
-		byCondition(columnId: string, values: Array<OSFramework.DataGrid.OSStructure.FilterCondition>): void;
-		byValue(columnId: string, values: Array<string>): void;
+		byCondition(columnId: string, values: Array<OSFramework.DataGrid.OSStructure.FilterCondition>, focusOnGrid?: boolean): void;
+		byValue(columnId: string, values: Array<string>, focusOnGrid?: boolean): void;
 		changeFilterType(columnID: string, filterType: wijmo.grid.filter.FilterType): void;
-		clear(columnID: string, triggerOnFiltersChange?: boolean): void;
+		clear(columnID: string, triggerOnFiltersChange?: boolean, focusOnGrid?: boolean): void;
 		deactivate(columnID: string): void;
 		setColumnFilterOptions(columnID: string, options: Array<string>, maxVisibleOptions?: number): void;
 	}

--- a/src/OSFramework/DataGrid/Feature/IGroupPanel.ts
+++ b/src/OSFramework/DataGrid/Feature/IGroupPanel.ts
@@ -6,8 +6,9 @@ namespace OSFramework.DataGrid.Feature {
 		/**
 		 * Add a given column or columns list to the grid group panel
 		 * @param binding binding of the column
+		 * @param focusOnGrid boolean to indicate if the grid should focus after adding the column to the group panel
 		 */
-		addColumnsToGroupPanel(binding: string): void;
+		addColumnsToGroupPanel(binding: string, focusOnGrid?: boolean): void;
 		/**
 		 * Check if the column is inside the Group Panel
 		 * @param binding binding of the column
@@ -16,8 +17,9 @@ namespace OSFramework.DataGrid.Feature {
 		/**
 		 * Remove a given column or columns list from the grid group panel
 		 * @param binding binding of the column
+		 * @param focusOnGrid boolean to indicate if the grid should focus after removing the column from the group panel
 		 */
-		removeColumnsFromGroupPanel(binding: string): void;
+		removeColumnsFromGroupPanel(binding: string, focusOnGrid?: boolean): void;
 		/**
 		 * Sets the column aggregation function inside the Group Panel
 		 * @param binding binding of the column

--- a/src/OSFramework/DataGrid/Types/index.ts
+++ b/src/OSFramework/DataGrid/Types/index.ts
@@ -239,4 +239,9 @@ namespace OSFramework.DataGrid.Types {
 		rowIndex: number;
 		selected: OSStructure.BindingValue[];
 	};
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	export type ObservableArray<T = any> = wijmo.collections.ObservableArray<T> & {
+		focusOnGrid?: boolean;
+	};
 }

--- a/src/OutSystems/GridAPI/ColumnManager.ts
+++ b/src/OutSystems/GridAPI/ColumnManager.ts
@@ -8,14 +8,15 @@ namespace OutSystems.GridAPI.ColumnManager {
 	 * @export
 	 * @param {string} gridID ID of the Grid where the change will occur.
 	 * @param {string} ListOfColumnIDs List of Ids of the Column blocks that will be programmatically added to the grid group panel.
+	 * @param {boolean} [focusOnGrid=true] If true, the Grid will be focused after the end of the operation
 	 */
-	export function AddColumnsToGroupPanel(gridID: string, ListOfColumnIDs: string): string {
+	export function AddColumnsToGroupPanel(gridID: string, ListOfColumnIDs: string, focusOnGrid = true): string {
 		Performance.SetMark('ColumnManager.AddColumnToGroupPanel');
 		const result = Auxiliary.CreateApiResponse({
 			gridID,
 			errorCode: OSFramework.DataGrid.Enum.ErrorCodes.API_FailedAddColumnToGroupPanel,
 			callback: () => {
-				GridManager.GetGridById(gridID).features.groupPanel.addColumnsToGroupPanel(ListOfColumnIDs);
+				GridManager.GetGridById(gridID).features.groupPanel.addColumnsToGroupPanel(ListOfColumnIDs, focusOnGrid);
 			},
 		});
 
@@ -194,14 +195,15 @@ namespace OutSystems.GridAPI.ColumnManager {
 	 * @export
 	 * @param {string} gridID ID of the Grid where the change will occur.
 	 * @param {string} ListOfColumnIDs List of Ids of the Column blocks that will be programmatically removed from the grid group panel.
+	 * @param {boolean} [focusOnGrid=true] If true, the Grid will be focused after the end of the operation
 	 */
-	export function RemoveColumnsFromGroupPanel(gridID: string, ListOfColumnIDs: string): string {
+	export function RemoveColumnsFromGroupPanel(gridID: string, ListOfColumnIDs: string, focusOnGrid = true): string {
 		Performance.SetMark('ColumnManager.RemoveColumnsFromGroupPanel');
 		const result = Auxiliary.CreateApiResponse({
 			gridID,
 			errorCode: OSFramework.DataGrid.Enum.ErrorCodes.API_FailedRemoveColumnsFromGroupPanel,
 			callback: () => {
-				GridManager.GetGridById(gridID).features.groupPanel.removeColumnsFromGroupPanel(ListOfColumnIDs);
+				GridManager.GetGridById(gridID).features.groupPanel.removeColumnsFromGroupPanel(ListOfColumnIDs, focusOnGrid);
 			},
 		});
 

--- a/src/OutSystems/GridAPI/Filter.ts
+++ b/src/OutSystems/GridAPI/Filter.ts
@@ -79,15 +79,16 @@ namespace OutSystems.GridAPI.Filter {
 	 * @param {string} gridID ID of the Grid that is to be to check from results.
 	 * @param {string} columnID ID of the column that will have filter cleared.
 	 * @param {boolean} [triggerOnFiltersChange=true] Flag to indicate if the OnFiltersChange event is to be triggered or not.
+	 * @param {boolean} [focusOnGrid=true] If true, the Grid will be focused after the end of the operation.
 	 * @returns {*}  {string} Return Message Success or message of error info if it's the case.
 	 */
-	export function Clear(gridID: string, columnID: string, triggerOnFiltersChange = true): string {
+	export function Clear(gridID: string, columnID: string, triggerOnFiltersChange = true, focusOnGrid = true): string {
 		Performance.SetMark('Filter.clear');
 		const result = Auxiliary.CreateApiResponse({
 			gridID,
 			errorCode: OSFramework.DataGrid.Enum.ErrorCodes.API_FailedFilterClear,
 			callback: () => {
-				GridManager.GetGridById(gridID).features.filter.clear(columnID, triggerOnFiltersChange);
+				GridManager.GetGridById(gridID).features.filter.clear(columnID, triggerOnFiltersChange, focusOnGrid);
 			},
 		});
 
@@ -127,15 +128,16 @@ namespace OutSystems.GridAPI.Filter {
 	 * @param {string} gridID ID of the Grid that is to be to check from results.
 	 * @param {string} columnID ID of the column that will be filtered.
 	 * @param {string} values Values on which the column will be filtered by.
+	 * @param {boolean} [focusOnGrid=true] If true, the Grid will be focused after the end of the operation.
 	 * @returns {*}  {string} Return Message Success or message of error info if it's the case.
 	 */
-	export function ByCondition(gridID: string, columnID: string, values: string): string {
+	export function ByCondition(gridID: string, columnID: string, values: string, focusOnGrid = true): string {
 		Performance.SetMark('Filter.ByCondition');
 		const result = Auxiliary.CreateApiResponse({
 			gridID,
 			errorCode: OSFramework.DataGrid.Enum.ErrorCodes.API_FailedFilterByCondition,
 			callback: () => {
-				GridManager.GetGridById(gridID).features.filter.byCondition(columnID, JSON.parse(values));
+				GridManager.GetGridById(gridID).features.filter.byCondition(columnID, JSON.parse(values), focusOnGrid);
 			},
 		});
 
@@ -152,15 +154,16 @@ namespace OutSystems.GridAPI.Filter {
 	 * @param {string} gridID ID of the Grid that is to be to check from results.
 	 * @param {string} columnID ID of the column that will be filtered.
 	 * @param {string} values Values on which the column will be filtered by.
+	 * @param {boolean} [focusOnGrid=true] If true, the Grid will be focused after the end of the operation.
 	 * @returns {*}  {string} Return Message Success or message of error info if it's the case.
 	 */
-	export function ByValue(gridID: string, columnID: string, values: string): string {
+	export function ByValue(gridID: string, columnID: string, values: string, focusOnGrid = true): string {
 		Performance.SetMark('Filter.ByValue');
 		const result = Auxiliary.CreateApiResponse({
 			gridID,
 			errorCode: OSFramework.DataGrid.Enum.ErrorCodes.API_FailedFilterByValue,
 			callback: () => {
-				GridManager.GetGridById(gridID).features.filter.byValue(columnID, JSON.parse(values));
+				GridManager.GetGridById(gridID).features.filter.byValue(columnID, JSON.parse(values), focusOnGrid);
 			},
 		});
 

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -37,7 +37,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 		}
 
 		private _filterChangedHandler(s: wijmo.grid.filter.FlexGridFilter) {
-			this._grid.features.undoStack.closeAction(ColumnFilterAction);
+			this._grid.features.undoStack.closeAction(ColumnFilterAction, false);
 
 			if (this._grid.gridEvents.hasHandlers(OSFramework.DataGrid.Event.Grid.GridEventType.OnFiltersChange)) {
 				this._grid.gridEvents.trigger(
@@ -157,7 +157,11 @@ namespace Providers.DataGrid.Wijmo.Feature {
 		 * @param columnId Column Id where the Filter will be performed
 		 * @param values Values to apply as column filter
 		 */
-		public byCondition(columnId: string, values: OSFramework.DataGrid.OSStructure.FilterCondition[]): void {
+		public byCondition(
+			columnId: string,
+			values: OSFramework.DataGrid.OSStructure.FilterCondition[],
+			focusOnGrid = true
+		): void {
 			const column = this._grid.getColumn(columnId);
 			if (column) {
 				const columnFilter = this._filter.getColumnFilter(column.provider).conditionFilter;
@@ -197,6 +201,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					this._filter.apply();
 					// trigger event
 					this._filterChangedHandler(this._filter);
+					if (focusOnGrid) {
+						this._grid.provider.focus();
+					}
 				}
 			} else {
 				throw new Error(OSFramework.DataGrid.Enum.ErrorMessages.InvalidColumnIdentifier);
@@ -209,7 +216,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 		 * @param columnId Column Id where the Filter will be performed
 		 * @param values Values to apply as column filter
 		 */
-		public byValue(columnId: string, values: Array<string>): void {
+		public byValue(columnId: string, values: Array<string>, focusOnGrid = true): void {
 			const column = this._grid.getColumn(columnId);
 			if (column) {
 				const isColumnTypeCheckbox = column.columnType === OSFramework.DataGrid.Enum.ColumnType.Checkbox;
@@ -239,6 +246,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
 				this._filter.apply();
 				// trigger event
 				this._filterChangedHandler(this._filter);
+				if (focusOnGrid) {
+					this._grid.provider.focus();
+				}
 			} else {
 				throw new Error(OSFramework.DataGrid.Enum.ErrorMessages.InvalidColumnIdentifier);
 			}
@@ -267,7 +277,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 		 * @param {boolean} [triggerOnFiltersChange=true] Flag to indicate if the OnFiltersChange event is to be triggered or not.
 		 * @memberof ColumnFilter
 		 */
-		public clear(columnID: string, triggerOnFiltersChange = true): void {
+		public clear(columnID: string, triggerOnFiltersChange = true, focusOnGrid = true): void {
 			const column = this._grid.getColumn(columnID);
 
 			if (column) {
@@ -275,6 +285,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
 				this._grid.provider.collectionView.refresh();
 				if (triggerOnFiltersChange) {
 					this._filterChangedHandler(this._filter);
+				}
+				if (focusOnGrid) {
+					this._grid.provider.focus();
 				}
 			} else {
 				throw new Error(OSFramework.DataGrid.Enum.ErrorMessages.InvalidColumnIdentifier);

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -36,8 +36,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			this._enabled = enabled;
 		}
 
-		private _filterChangedHandler(s: wijmo.grid.filter.FlexGridFilter) {
-			this._grid.features.undoStack.closeAction(ColumnFilterAction, false);
+		private _filterChangedHandler(s: wijmo.grid.filter.FlexGridFilter, focusOnGrid = true) {
+			this._grid.features.undoStack.closeAction(ColumnFilterAction, focusOnGrid);
 
 			if (this._grid.gridEvents.hasHandlers(OSFramework.DataGrid.Event.Grid.GridEventType.OnFiltersChange)) {
 				this._grid.gridEvents.trigger(
@@ -200,10 +200,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
 					this._filter.apply();
 					// trigger event
-					this._filterChangedHandler(this._filter);
-					if (focusOnGrid) {
-						this._grid.provider.focus();
-					}
+					this._filterChangedHandler(this._filter, focusOnGrid);
 				}
 			} else {
 				throw new Error(OSFramework.DataGrid.Enum.ErrorMessages.InvalidColumnIdentifier);
@@ -245,10 +242,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
 				this._filter.apply();
 				// trigger event
-				this._filterChangedHandler(this._filter);
-				if (focusOnGrid) {
-					this._grid.provider.focus();
-				}
+				this._filterChangedHandler(this._filter, focusOnGrid);
 			} else {
 				throw new Error(OSFramework.DataGrid.Enum.ErrorMessages.InvalidColumnIdentifier);
 			}
@@ -284,9 +278,10 @@ namespace Providers.DataGrid.Wijmo.Feature {
 				this._filter.getColumnFilter(column.provider).clear();
 				this._grid.provider.collectionView.refresh();
 				if (triggerOnFiltersChange) {
-					this._filterChangedHandler(this._filter);
+					this._filterChangedHandler(this._filter, focusOnGrid);
 				}
-				if (focusOnGrid) {
+				// If not triggering the event and focusOnGrid is true, we focus the grid
+				else if (focusOnGrid) {
 					this._grid.provider.focus();
 				}
 			} else {

--- a/src/Providers/DataGrid/Wijmo/Features/GroupPanel.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/GroupPanel.ts
@@ -64,8 +64,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					this._dragCol && this._addGroup(this._dragCol, e);
 		}
 
-		public addColumnsToGroupPanel(bindingList: string): void {
-			const groupDescriptions = this._grid.provider.collectionView.groupDescriptions; // Group array
+		public addColumnsToGroupPanel(bindingList: string, focusOnGrid = true): void {
+			const groupDescriptions = this._grid.provider.collectionView
+				.groupDescriptions as OSFramework.DataGrid.Types.ObservableArray; // Group array
 			const columnList = JSON.parse(bindingList);
 			const source = this._grid.provider.itemsSource;
 			source.deferUpdate(() => {
@@ -76,7 +77,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 							const groupDescription = new wijmo.collections.PropertyGroupDescription(
 								column.config.binding
 							);
-
+							groupDescriptions.focusOnGrid = focusOnGrid;
 							groupDescriptions.push(groupDescription);
 							column.provider.visible = false;
 						}
@@ -102,7 +103,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			//this way we can easily handle the "x" to remove items from grouppanel
 			this._grid.provider.itemsSource.groupDescriptions.collectionChanged.addHandler(
 				(
-					o: wijmo.collections.ObservableArray /*,
+					o: OSFramework.DataGrid.Types.ObservableArray /*,
                     e: wijmo.collections.NotifyCollectionChangedEventArgs*/
 				) => {
 					const grid = this._grid;
@@ -111,7 +112,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					grid.features.undoStack.startAction(
 						new GroupPanelAction(grid.provider, this._currGroupDescription)
 					);
-					grid.features.undoStack.closeAction(GroupPanelAction);
+					grid.features.undoStack.closeAction(GroupPanelAction, o.focusOnGrid);
 
 					const oldGroupDescription = this._currGroupDescription;
 
@@ -161,8 +162,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			});
 		}
 
-		public removeColumnsFromGroupPanel(bindingList: string): void {
-			const groupDescriptions = this._grid.provider.collectionView.groupDescriptions; // Group array
+		public removeColumnsFromGroupPanel(bindingList: string, focusOnGrid = true): void {
+			const groupDescriptions = this._grid.provider.collectionView.groupDescriptions as OSFramework.DataGrid.Types.ObservableArray; // Group array
 			const columnList = JSON.parse(bindingList);
 			const source = this._grid.provider.itemsSource;
 
@@ -180,6 +181,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
 						// If the group description exists, remove it
 						if (index > -1) {
+							groupDescriptions.focusOnGrid = focusOnGrid;
 							groupDescriptions.splice(index, 1);
 							// Make the column visible again
 							column.provider.visible = true;


### PR DESCRIPTION
This pull request introduces enhancements to the DataGrid filtering and grouping APIs by adding a new `focusOnGrid` parameter to several methods. This parameter allows programmatic control over whether the grid should receive focus after filter or group panel operations, improving accessibility and user experience. The changes affect both the API surface and internal implementations for filters and group panels.

### API and Interface Changes

* Added optional `focusOnGrid` parameter to the methods `byCondition`, `byValue`, and `clear` in the `IColumnFilter` interface, and to `addColumnsToGroupPanel` and `removeColumnsFromGroupPanel` in the `IGroupPanel` interface, enabling grid focus after these operations.
* Updated API functions in `OutSystems.GridAPI.ColumnManager.ts` and `OutSystems.GridAPI.Filter.ts` to accept the new `focusOnGrid` parameter, defaulting to `true` for backward compatibility. 

### Implementation Updates

* Modified the internal logic in `ColumnFilter.ts` and `GroupPanel.ts` to pass and handle the `focusOnGrid` parameter, focusing the grid provider when requested after filter or group panel actions. 

### Type and Event Handling

* Extended the `ObservableArray` type in `Types/index.ts` to include the optional `focusOnGrid` property, propagating focus intent through event handling and undo stack logic.

### Minor Adjustments

* Updated undo stack method calls to handle the new `focusOnGrid` argument, ensuring correct focus behavior after undo/redo actions for filters and group panel changes. 


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

