### PR TITLE
ROU-12058: Fix checkbox showing shadow when cell is not selected

### DIFF
--- a/styles/Grid.css
+++ b/styles/Grid.css
@@ -291,10 +291,6 @@
     box-shadow: inset 0 0 0 1px var(--color-primary);
 }
 
-.wj-cells .wj-cell[aria-selected='true']:not(.wj-state-multi-selected) {
-    box-shadow: inset 0 0 0 1px var(--color-primary);
-}
-
 .wj-frozen.wj-frozen-col.wj-state-active.wj-state-selected,
 .wj-frozen.wj-frozen-col,
 .wj-header.wj-state-multi-selected.wj-frozen-col,


### PR DESCRIPTION
This PR is for fixing an issue with checkbox styling.

### What was happening
* After some changes in the latest Wijmo update, the box-shadow started to appears when the checkbox cell was not selected.

### What was done
* Removed the box-shadow style that is not needed anymore.

### Screenshots
Before:
<img width="187" height="340" alt="image" src="https://github.com/user-attachments/assets/b66de752-3f16-457e-bbd1-0b467bb54846" />

After:
<img width="204" height="349" alt="image" src="https://github.com/user-attachments/assets/0aa17f79-2c0a-452e-9771-6b758453fd63" />


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

