### PR TITLE
ROU-12277: Review filter CSS after Wijmo fix

### DIFF
--- a/styles/Grid.css
+++ b/styles/Grid.css
@@ -850,9 +850,6 @@ div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
     font-size: var(--datagrid-filter-font-size);
     font-weight: var(--font-regular);
     line-height: 18px;
-    padding: var(--datagrid-button-padding) 0px;
-    text-align: center;
-    width: 100%;
 }
 
 .wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor
@@ -870,56 +867,70 @@ div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
     -webkit-filter: brightness(0.8);
 }
 
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor
-    > div
-    > div:last-child {
+/* header(tab panel) */
+.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor .wj-tabpanel .wj-tabheaders {
     display: flex;
-    justify-content: center;
-}
-
-/**** Commented because of layout issues in the filter introduced by Wijmo and need to be uncommented once fixed (ROU-12277) ****/
-/* .wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor
-    .wj-valuefilter-editor {
-    margin-top: -6px;
-} */
-
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor .wj-filtertype {
-    color: transparent;
-    display: flex;
-    flex-wrap: nowrap;
     font-size: 10px;
-    justify-content: center;
-    margin-top: 5px;
 }
 
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor
-    .wj-filtertype
-    > * {
-    align-items: center;
-    border-bottom: 2px solid transparent;
-    color: var(--datagrid-color) !important;
-    display: flex;
-    justify-content: center;
-    padding-bottom: 10px;
-    text-align: center;
-    text-decoration: none;
+.wj-tabpanel > div > .wj-tabheaders > .wj-tabheader {
+    padding-bottom: 12px;
+    flex-grow: 1;
+}
+
+.wj-tabpanel > div > .wj-tabheaders > .wj-tabheader:after {
+    left: 0;
     width: 100%;
+    transition: all 180ms linear;
+    height: 2px;
 }
 
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor
-    .wj-filtertype
-    > *:hover {
-    border-bottom: 2px solid var(--color-neutral-5);
-    text-decoration: none;
+.wj-tabpanel > div > .wj-tabheaders > .wj-tabheader:not(.wj-state-active):hover:after {
+    background: var(--color-neutral-5);
+    visibility: visible;
 }
 
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor
-    .wj-filtertype
-    .wj-state-disabled {
-    border-bottom: 2px solid var(--color-primary);
+.wj-tabpanel > div > .wj-tabheaders > .wj-tabheader.wj-state-active:after {
+    background: var(--color-primary);
+}
+
+.wj-tabpanel > div > .wj-tabheaders > .wj-tabheader.wj-state-active {
     color: var(--datagrid-color);
-    opacity: 1;
-    width: 100%;
+}
+
+/* search */
+.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor span.wj-glyph-search {
+    margin-top: 6px;
+}
+
+.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor .wj-tabpanel .wj-tabpanes {
+    border-top: none;
+}
+
+/* select all and include selection */
+
+.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-options] label[wj-part=select-all-container] span[wj-part=sp-select-all],
+.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-options] label[wj-part=lbl-include-sel] span[wj-part=sp-include-sel]{
+    top: 0;
+}
+
+/* checklist item */
+.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor label.wj-checklist-item {
+    display: flex;
+    align-items: center;
+    margin-top: 4px;
+}
+
+/* checklist item checkbox */
+
+.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-values] .wj-checklist-item span.wj-checklist-mark {
+    position: absolute;
+    top: 55%;
+}
+
+/* checklist item caption */
+.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-values] .wj-checklist-item span.wj-checklist-caption {
+    margin-left: 2px;
 }
 
 /***** PLACEHOLDERS STYLE *****/
@@ -1287,100 +1298,4 @@ div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
 
 .server-side-message > .server-side-pagination-link {
     -servicestudio-color: #006de9;
-}
-
-/**** The styles below fix layout issues in the filter introduced by Wijmo and need be removed once fixed (ROU-12277) ****/
-/* container */
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-type] {
-    flex-direction: column;
-}
-
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-type] > div.wj-tabpanel {
-    margin-bottom: 0;
-}
-
-/* header(tab panel) */
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor .wj-tabpanel .wj-tabheaders {
-    display: flex;
-    font-size: 10px;
-    margin-bottom: 10px;
-}
-
-.wj-tabpanel > div > .wj-tabheaders > .wj-tabheader {
-    padding-bottom: 12px;
-}
-
-.wj-tabpanel > div > .wj-tabheaders > .wj-tabheader:after {
-    left: 0;
-    width: 100%;
-    visibility: visible;
-    opacity: 0;
-    transition: all 180ms linear;
-    height: 2px;
-}
-
-.wj-tabpanel > div > .wj-tabheaders > .wj-tabheader:not(.wj-state-active):hover:after {
-    background: var(--color-neutral-5);
-    opacity: 1;
-}
-
-.wj-tabpanel > div > .wj-tabheaders > .wj-tabheader.wj-state-active:after {
-    background: var(--color-primary);
-    opacity: 1;
-}
-
-.wj-tabpanel > div > .wj-tabheaders > .wj-tabheader.wj-state-active {
-    color: var(--datagrid-color);
-}
-
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor .wj-valuefilter-editor {
-    margin-top: 0;
-}
-
-/* footer(button container) */
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-type] > div:last-child {
-    display: flex;
-}
-
-/* search */
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor span.wj-glyph-search {
-    margin-top: 6px;
-}
-
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor .wj-tabpanel .wj-tabpanes {
-    border-top: none;
-}
-
-/* select all and include selection */
-
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-options] label[wj-part=select-all-container] span[wj-part=sp-select-all],
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-options] label[wj-part=lbl-include-sel] span[wj-part=sp-include-sel]{
-    top: 0;
-}
-
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-options] label[wj-part=select-all-container] span[wj-part=sp-select-all] {
-    top: 0;
-}
-
-/* checklist item */
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor label.wj-checklist-item {
-    display: flex;
-    align-items: center;
-}
-
-/* checklist first item */
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor label.wj-checklist-item:nth-of-type(1) {
-    margin-top: 4px;
-}
-
-/* checklist item checkbox */
-
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-values] .wj-checklist-item span.wj-checklist-mark {
-    position: absolute;
-    top: 55%;
-}
-
-/* checklist item caption */
-.wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor div[wj-part=div-values] .wj-checklist-item span.wj-checklist-caption {
-    margin-left: 2px;
 }


### PR DESCRIPTION
This PR is for re-organize and clean grid styles. 

### What was done
* remove unused styles;
* re-organize content;

### Test Steps
1. Check filter column popover experience
2. Compare it with the version before these changes  

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

