### PR TITLE
ROU-12281: Fix dirty mark issue with undo after Mark Changes As Saved

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/UndoStack.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/UndoStack.ts
@@ -20,6 +20,15 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			}
 		}
 
+		private _undoingActionHandler(undoStack: wijmo.undo.UndoStack, e: wijmo.undo.UndoActionEventArgs): void {
+			if (e.action instanceof wijmo.undo.GridEditAction) {
+				const gridAction = e.action as wijmo.undo.GridEditAction;
+				const row = gridAction.row;
+				const col = gridAction.col;
+				this._grid.features.dirtyMark.saveOriginalValue(row, col);
+			}
+		}
+
 		public get stack(): wijmo.undo.UndoStack {
 			return this._undoStack;
 		}
@@ -31,6 +40,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					maxActions: 50,
 				}
 			);
+			this._undoStack.undoingAction.addHandler(this._undoingActionHandler.bind(this));
 		}
 
 		public clear(): void {

--- a/src/Providers/DataGrid/Wijmo/Features/UndoStack.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/UndoStack.ts
@@ -22,7 +22,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
 		private _undoingActionHandler(undoStack: wijmo.undo.UndoStack, e: wijmo.undo.UndoActionEventArgs): void {
 			if (e.action instanceof wijmo.undo.GridEditAction) {
-				const gridAction = e.action as wijmo.undo.GridEditAction;
+				const gridAction = e.action;
 				const row = gridAction.row;
 				const col = gridAction.col;
 				this._grid.features.dirtyMark.saveOriginalValue(row, col);


### PR DESCRIPTION
This pull request fixes an issue that caused the dirty mark to not be added when performing undo after marking changes as saved.  It improves the undo functionality in the Wijmo DataGrid provider by ensuring that original cell values are properly saved before an undo action is performed. The most significant changes are as follows:

**Undo stack event handling:**

* Added a private `_undoingActionHandler` method to `UndoStack.ts` that listens for undo actions. When a grid edit action is being undone, it saves the original value of the affected cell using the `dirtyMark` feature.
* Registered the `_undoingActionHandler` as an event handler for the `undoingAction` event on the `wijmo.undo.UndoStack` instance, ensuring the handler is called whenever an undo is triggered.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

