### PR TITLE
RPM-6373: Unwanted scroll after Copy/Export action in frozen columns

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -273,7 +273,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
 			// Restore focus to active grid cell
 			if (cell) {
-				cell.focus();
+				cell.focus({ preventScroll: true });
 			}
 		}
 


### PR DESCRIPTION
This pull request makes a minor improvement to the grid context menu feature. The change ensures that when focus is restored to a grid cell, the page does not scroll unexpectedly.

* Updated the `cell.focus()` call in `ContextMenu.ts` to use `{ preventScroll: true }`, preventing unwanted scrolling when restoring focus to the active grid cell.

### Test Steps
Prepare the sample:

1. Add a Grid with a large dataset
2. Set the first column as frozen
3. Set the cloneFrozenCells of the provider’s Grid to true: `OutSystems.GridAPI.GridManager.GetActiveGrid().provider.cloneFrozenCells = true;`
4. Scroll to the grid to the bottom
5. Right click on the last cell of the frozen column
6. Click Export > to CSV or just Copy
7. The Grid does not scrolls to the top.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

