### PR TITLE
ROU-12515: Saved View filters don't show in UI since version 2.21.0

### DIFF
--- a/gulp/DefaultSpecs.js
+++ b/gulp/DefaultSpecs.js
@@ -19,7 +19,7 @@ const constants = {
 
 // Store the default project specifications
 const specs = {
-	version: '2.21.1',
+	version: '2.21.2',
 	name: 'OutSystems DataGrid',
 	description: '',
 	url: 'Website:\n • ' + constants.websiteUrl,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outsystems-datagrid",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "description": "OutSystems Data Grid for Reactive Web",
   "author": "UI Components Team",
   "license": "BSD-3-Clause",

--- a/src/OSFramework/DataGrid/Constants.ts
+++ b/src/OSFramework/DataGrid/Constants.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.DataGrid.Constants {
 	/* OutSystems Data Grid Version */
-	export const OSDataGridVersion = '2.21.1';
+	export const OSDataGridVersion = '2.21.2';
 	/* OutSystems null values */
 	export const OSNullDate = '1900-01-01';
 	export const OSNullDateTime = '1900-01-01T00:00:00';

--- a/src/Providers/DataGrid/Wijmo/Features/View.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/View.ts
@@ -94,19 +94,16 @@ namespace Providers.DataGrid.Wijmo.Feature {
 		 */
 		private _setGroups(columns, config) {
 			for (let i = 0; i < config.length; i++) {
-				let colDef = columns.filter((x) => x.header === config[i].header);
+				const colDef = columns.filter((x) => x.header === config[i].header);
 				if (colDef.length > 0) {
-					colDef = colDef[0];
+					const colToUpdate = colDef[0];
 					if (config[i].children && config[i].children.length > 0) {
-						this._setGroups(colDef.columns, config[i].children[0]);
+						this._setGroups(colToUpdate.columns, config[i].children[0]);
 					}
-					columns.remove(colDef);
 					// due to Wijmo's breaking change, in case it is not defined, we need to assign an empty string to collapseTo property
-					colDef.collapseTo = config[i].collapseTo ?? '';
-					colDef.isCollapsed = config[i].isCollapsed || false; // in case it wasn't defined, set to false
-					colDef.align = config[i].align || colDef.align;
-
-					columns.insert(i, colDef);
+					colToUpdate.collapseTo = config[i].collapseTo ?? '';
+					colToUpdate.isCollapsed = config[i].isCollapsed || false; // in case it wasn't defined, set to false
+					colToUpdate.align = config[i].align || colToUpdate.align;
 				}
 			}
 		}

--- a/src/Providers/DataGrid/Wijmo/Features/View.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/View.ts
@@ -136,12 +136,12 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
 			const config = JSON.parse(state);
 			this._grid.provider.deferUpdate(() => {
-				this._reloadColumns(config);
 				this._grid.features.filter.setViewLayout(config);
 				this._grid.features.groupPanel.setViewLayout(config);
 				this._grid.features.sort.setViewLayout(config);
 				this._grid.features.columnFreeze.setViewLayout(config);
 				this._setGroups(this._grid.provider.columnGroups, config.groupColumns);
+				this._reloadColumns(config);
 			});
 		}
 	}


### PR DESCRIPTION
This PR is for fix the filter not being visually applied when using SetViewLayout.

### What was happening
* After the last Wijmo update, the filter is not being shown as applied when using the `SetViewLayout` API. although the data is affected. 
* When applying a layout when the Grid has a column added to the GroupPanel, this column will remain invisible after the action.

### What was done
* The first issue was happening because after the filter is correctly applied in [line 140 of the View.ts](https://github.com/OutSystems/outsystems-datagrid/blob/f9390ee0a207cd8daf8ddae13171acf02394378a/src/Providers/DataGrid/Wijmo/Features/View.ts#L140), we were deleting the column from the `columns` object in the [ `_setGroups` method](https://github.com/OutSystems/outsystems-datagrid/blob/f9390ee0a207cd8daf8ddae13171acf02394378a/src/Providers/DataGrid/Wijmo/Features/View.ts#L95) which was causing the reported issue.
* The second issue happened because when the `this._reloadColumns()` is called, a refresh of the columns is done. During this refresh, the visibility of the column is set based on the presence of this column in the Group Panel - when the column is in the Group Panel. it's visibility is set to false. This issue was fixed by moving the `reloadColumns()` execution after all the other operations related to the layout, this way, the Visibility of the columns will only be set after the columns in the GroupPanel are correctly added/ removed based on the layout.
* Updated the version to 2.21.2

### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

