### PR TITLE
ROU-11908: Fixed multiple requests for language files

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Helper/Translation.ts
+++ b/src/Providers/DataGrid/Wijmo/Helper/Translation.ts
@@ -12,26 +12,17 @@ namespace Providers.DataGrid.Wijmo.Helper.Translation {
 	export function SetLanguage(language: string): void {
 		if (DataGrid.Wijmo.Language.IsLanguageSupported(language)) {
 			const url = DataGrid.Wijmo.Language.GetLanguageFilePath(language);
-
-			fetch(url, { method: 'HEAD' }).then(function (response) {
-				if (response.ok) {
-					// this callback is wijmo's workaround to translate the group panel. Remove once they've fixed
-					OSFramework.DataGrid.Helper.DynamicallyLoadScript(url, () => {
-						const gps = document.body.querySelectorAll('.wj-control.wj-grouppanel');
-						const culture = wijmo.culture;
-						for (let i = 0; i < gps.length; i++) {
-							const gp = wijmo.Control.getControl(gps[i]);
-							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-							// @ts-ignore
-							gp.placeholder = culture.GroupPanel.dragDrop;
-						}
-						FormatDateOperators();
-						wijmo.Control.invalidateAll();
-					});
-				} else {
-					//if the language resource is not found in the server, then throw an error and let the english be the default language.
-					throw `The language "${language}" is not supported. Falling back to the language in use.`;
+			OSFramework.DataGrid.Helper.DynamicallyLoadScript(url, () => {
+				const gps = document.body.querySelectorAll('.wj-control.wj-grouppanel');
+				const culture = wijmo.culture;
+				for (let i = 0; i < gps.length; i++) {
+					const gp = wijmo.Control.getControl(gps[i]);
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore
+					gp.placeholder = culture.GroupPanel.dragDrop;
 				}
+				FormatDateOperators();
+				wijmo.Control.invalidateAll();
 			});
 		} else {
 			throw `The language "${language}" is not supported. Falling back to the language in use.`;

--- a/src/Providers/DataGrid/Wijmo/Language/Languages.ts
+++ b/src/Providers/DataGrid/Wijmo/Language/Languages.ts
@@ -12,6 +12,7 @@ namespace Providers.DataGrid.Wijmo.Language {
 			case 'de-CH':
 			case 'en-CA':
 			case 'en-GB':
+			case 'es-419':
 			case 'es-MX':
 			case 'fr-CA':
 			case 'mn-MN':


### PR DESCRIPTION
This PR is to fix the multiple requests sent for language files when multiple Grids are displayed on the same page


### What was happening
* When a screen had multiple Grids, multiple requests for the language files were being made

![Screen Recording 2026-02-19 at 18 28 09](https://github.com/user-attachments/assets/04d8b6a0-dd06-4c9c-8d99-1fc7d39a20ae)


### What was done
* Logic was changed to ensure that only one request is made per page, even though multiple Grids exist

### Test Steps
1. Open the browser with developer tools in the network tab
2. Open the sample application 
3. Filter by 'wijmo_culture' file name
4. Validate that only one request is done


### Screenshots
![Screen Recording 2026-02-19 at 18 27 40](https://github.com/user-attachments/assets/4909deba-7bd8-4bcb-90b1-f872ed67fc7f)


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

