### PR TITLE
ROU-12552: Replace Snyk with Wiz ignores

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,4 +7,4 @@ src/libraries/**
 *.d.ts
 *.js
 # don't lint settings
-*.snyk
+.wiz

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,4 +6,4 @@ src/@types
 *.css
 
 # don't lint settings
-*.snyk
+.wiz

--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,0 @@
-exclude:
- global:
-   - gulp/**
-   - pipelines/**
-   - docs/**

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -6,4 +6,4 @@ src/static/**
 *.css
 
 # don't lint settings
-*.snyk
+.wiz

--- a/.wiz
+++ b/.wiz
@@ -1,8 +1,8 @@
 ignore:
     global_paths:
-        "gulp/**":
+        /gulp/**:
             reason: BY_DESIGN
-        "pipelines/**":
+        /pipelines/**:
             reason: BY_DESIGN
-        "docs/**":
+        /docs/**:
             reason: BY_DESIGN

--- a/.wiz
+++ b/.wiz
@@ -1,0 +1,8 @@
+ignore:
+    global_paths:
+        "gulp/**":
+            reason: BY_DESIGN
+        "pipelines/**":
+            reason: BY_DESIGN
+        "docs/**":
+            reason: BY_DESIGN


### PR DESCRIPTION
- Replace Snyk with Wiz ignores
- The `.wiz` file needs to follow the syntax from [this](https://docs.wiz.io/docs/exception-management-with-wiz-code#configuration-file-wiz) documentation, which is the closest to the same rules from Snyk that can be checked [here](https://docs.snyk.io/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import).

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)