### PR TITLE
ROU-12718: Update lodash version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing to OutSystems Data Grid
 
-Thank you for contributing to this project. This repository contains TypeScript code that wraps Wijmo to create data grids in OutSystems Reactive Web applications.
+This repository contains TypeScript code that wraps Wijmo FlexGrid for OutSystems Reactive Web applications, along with a .NET extension for server-side data preparation.
 
 ## Development Setup
 
 ### Prerequisites
 
-- Node.js 12 or higher (defined in `package.json` engines field)
+- Node.js 12 or higher (see `engines` in `package.json`)
 - Visual Studio Code (recommended)
 - For .NET extension work: Visual Studio with .NET Framework 4.7.2
 
@@ -14,10 +14,10 @@ Thank you for contributing to this project. This repository contains TypeScript 
 
 Defined in `.vscode/extensions.json`:
 
-- Prettier - Code formatter (`esbenp.prettier-vscode`)
+- Prettier (`esbenp.prettier-vscode`)
 - Document This (`oouo-diogo-perdigao.docthis`)
 - GitBlame (`waderyan.gitblame`)
-- ESLint (`bdaeumer.vscode-eslint`)
+- ESLint (`dbaeumer.vscode-eslint`)
 
 ### Initial Setup
 
@@ -25,17 +25,16 @@ Defined in `.vscode/extensions.json`:
 npm run setup
 ```
 
-This installs dependencies and compiles the code.
+This installs dependencies and starts development mode with browser-sync.
 
 ## Development Workflow
 
 ### Branch Naming
 
-Create your branch from `dev` using the JIRA ticket identifier:
+Create branches from `dev` using the JIRA ticket identifier:
 
 ```bash
-git checkout dev
-git pull
+git checkout dev && git pull
 git checkout -b ROU-12345
 ```
 
@@ -43,129 +42,99 @@ Branch names follow the pattern `<JIRA-ID>` (e.g., `ROU-12345`, `RGRIDT-1051`).
 
 ### Commit Format
 
-Commits should include the JIRA ticket ID and a brief description:
+Include the JIRA ticket ID and a brief description:
 
 ```
 ROU-12345: Add new feature for data export
 ```
 
-### Pull Request Requirements
+### PR Title
 
-**PR Title:** Must match the pattern `<JIRA-ID>: <description>` (e.g., `ROU-12345: Add support for CSV export`)
+Must match the regex `^([A-Z][A-Z0-9]*-\d+(:)?\s\w)` -- for example, `ROU-12345: Add CSV export support`. Release and merge branches are exempt from this check.
 
-The title is validated using the regex: `^([A-Z][A-Z0-9]*-\d+(:)?\s\w)`. Release and merge branches are exempt.
+### PR Labels
 
-Validation defined in: `.github/actions/validate-pr-title/action.yml`
-
-**PR Labels:** Must include at least one of:
-
-- `feature` - New functionality
-- `bug` / `bugfix` - Bug fixes
-- `chore` - Maintenance tasks
-- `dependencies` / `dependency` - Dependency updates
+At least one required: `feature`, `bug`, `bugfix`, `dependencies`, `dependency`, `chore`.
 
 Must NOT have the `do not merge` label.
 
-Validation defined in: `.github/actions/validate-pr-labels/action.yml`
+### PR Description
 
-**PR Description:** Use the template (`.github/pull_request_template.md`) to provide:
+Use the template (`.github/pull_request_template.md`) which asks for:
 
-- Link to sample page demonstrating the change
+- Link to a sample page demonstrating the change
 - What was happening (issue description)
 - What was done (solution description)
-- Test steps
-- Screenshots (animated GIFs preferred)
-- Checklist confirmation
+- Test steps and screenshots (animated GIFs preferred)
+- Checklist confirmation (local testing, documentation, ESLint clean)
 
-**Approval:** Requires approval from a UI Components team member.
+### Approval
+
+Requires approval from a UI Components team member. Code ownership is defined in `.github/CODEOWNERS` (`@OutSystems/rd-ui-components`).
+
+### CI Checks
+
+PRs targeting `dev` trigger an automated build (`npm install` then `npm run build`). PR title and label validations also run automatically.
 
 ## Building and Testing
 
 | Command            | Description                                    |
 | ------------------ | ---------------------------------------------- |
-| `npm run setup`    | Install dependencies and compile               |
-| `npm run build`    | Build production output, run lintfix, and lint |
-| `npm run dev`      | Start development mode with gulp               |
-| `npm run lint`     | Check code style (TypeScript files)            |
-| `npm run lintfix`  | Auto-fix code style issues                     |
+| `npm run setup`    | Install dependencies and start dev mode        |
+| `npm run build`    | Production build + lintfix + lint              |
+| `npm run dev`      | Start dev server (browser-sync, port 3000)     |
+| `npm run lint`     | Check TypeScript code style (ESLint)           |
+| `npm run lintfix`  | Auto-fix ESLint issues                         |
 | `npm run prettier` | Format all JS/TS/CSS files                     |
 | `npm run docs`     | Generate TypeDoc documentation                 |
 
-**Build Requirements:**
-
-- Code must compile without errors
-- Code must pass ESLint checks without errors or warnings
-- Code must follow Prettier formatting conventions
+`npm run build` must pass without errors or warnings before submitting a PR.
 
 ### .NET Extension
 
-For changes to the DataGridUtils extension (in `extension/DataGridUtils/Source/NET/`):
+For changes to the DataGridUtils extension (`extension/DataGridUtils/Source/NET/`):
 
-1. Open `DataGridUtils.sln` in Visual Studio
-2. Build the project targeting .NET Framework 4.7.2
-3. Test with OutSystems Integration Studio
+1. Open `extension/DataGridUtils/Source/NET/DataGridUtils.sln` in Visual Studio
+2. Build targeting .NET Framework 4.7.2
+3. Run console tests in `extension/tests/DataGridUtils.Tests.csproj`
+
+Do not modify files under `extension/DataGridUtils/Templates/NET/` -- those are auto-generated by Integration Studio.
+
+### Test Automation
+
+Browser-based integration tests live in a separate repository: [outsystems-datagrid-tests](https://github.com/OutSystems/outsystems-datagrid-tests) (WebDriverIO + Cucumber). It is checked out locally at `../outsystems-datagrid-tests`.
 
 ## Code Standards
 
 ### TypeScript
 
-Enforced by `.eslintrc.json` and `.prettierrc.json`:
+Enforced by `.eslintrc.json` and `.prettierrc.json`. Run `npm run lintfix` before committing.
 
-**Naming Conventions:**
+**Naming conventions** (enforced by `@typescript-eslint/naming-convention`):
 
-- Exported functions: `StrictPascalCase`
-- Classes: `StrictPascalCase`
-- Interfaces: `IStrictPascalCase` or `UPPER_CASE` (prefix with `I`)
-- Private class properties: `_strictCamelCase` (leading underscore required)
-- Public/protected properties: `strictCamelCase` (no underscore)
-- Private methods: `_strictCamelCase` (leading underscore required)
-- Public/protected methods: `strictCamelCase` (no underscore)
+| Selector              | Format              | Underscore        |
+| --------------------- | ------------------- | ----------------- |
+| Exported functions    | `StrictPascalCase`  | --                |
+| Classes               | `StrictPascalCase`  | --                |
+| Interfaces            | `IStrictPascalCase` | prefix with `I`   |
+| Private properties    | `_strictCamelCase`  | leading required  |
+| Public/protected props| `strictCamelCase`   | leading forbidden |
+| Private methods       | `_strictCamelCase`  | leading required  |
+| Public/protected methods | `strictCamelCase` | leading forbidden |
 
-**Member Ordering:**
+**Member ordering** (enforced by `@typescript-eslint/member-ordering`):
 
-- Classes: signature, private/protected/public fields, constructor, private/protected/public methods, abstract methods
-- Within each category: alphabetically sorted
+Classes: signature, private fields, protected fields, public fields, constructor, private methods, protected methods, public methods, abstract methods -- alphabetically within each group.
 
-**Code Style:**
+**Formatting** (Prettier): tabs (width 4), single quotes, semicolons required, 120-char line width, ES5 trailing commas.
 
-- Use tabs for indentation (width 4)
-- Single quotes for strings
-- Semicolons required
-- Maximum line width: 120 characters
-- Trailing commas in ES5 style
-- Use strict equality (`===`)
-
-**Documentation:**
-
-- Document all public APIs using JSDoc comments
-- Use the "Document This" extension: type `/**` above a function/class
-- Explain the "why" of complex logic, not just the "what"
+**Documentation:** Use JSDoc comments on all public APIs. The "Document This" VS Code extension generates stubs when you type `/**` above a function.
 
 ### General Guidelines
 
-- Avoid unnecessary commits; keep git history clean
-- Keep branches updated with `dev` when possible
-- Document your code thoroughly
-- Avoid changes outside the scope of your issue
-- Do not expose sensitive information (server URLs, credentials, etc.)
-
-## Pull Request Process
-
-1. Ensure your branch is up to date with `dev`
-2. Run `npm run build` and fix all errors/warnings
-3. Test your changes locally
-4. Create a PR from your branch to `dev`
-5. Fill out the pull request template completely
-6. Address review feedback from team members
-7. Once approved by a team member, the PR will be merged
-
-## Testing
-
-The Data Grid has a separate test automation repository: [outsystems-datagrid-tests](https://github.com/OutSystems/outsystems-datagrid-tests)
-
-This repository contains browser-based integration tests using WebdriverIO and Cucumber. Contributors working on the main repository should be aware this test repository exists for QA validation.
-
-For internal contributors, testing setup information is available via the `#rd-uicomponents-contributors` Slack channel.
+- Keep changes scoped to the relevant JIRA ticket
+- Do not modify Wijmo type definitions in `src/@types/`
+- Do not expose sensitive information (server URLs, credentials)
 
 ## Getting Help
 
@@ -176,10 +145,10 @@ For internal contributors, testing setup information is available via the `#rd-u
 
 ## Useful Resources
 
-- [Forge component - O11:](https://www.outsystems.com/forge/component-overview/9764/outsystems-data-grid-o11)
-- [Forge component - ODC:](https://www.outsystems.com/forge/component-overview/15929/outsystems-data-grid-odc)
-- [Sample Application](https://www.outsystems.com/forge/component-overview/9765/data-grid-sample-reactive)
 - [Living Documentation](https://outsystemsui.outsystems.com/OutSystemsDataGridSample/)
+- [Forge Component - O11](https://www.outsystems.com/forge/component-overview/9764/outsystems-data-grid-o11)
+- [Forge Component - ODC](https://www.outsystems.com/forge/component-overview/15929/outsystems-data-grid-odc)
+- [Sample Application](https://www.outsystems.com/forge/component-overview/9765/data-grid-sample-reactive)
 - [Tutorial: Data Grid in less than 4 minutes](https://www.youtube.com/watch?v=OFXOPrkRlrI)
 
 ## License

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > **Repository:** outsystems-datagrid
 > **Runtime Environment:** User Browser (TypeScript/JavaScript) + OutSystems Server (.NET Extension)
-> **Last Updated:** 2026-03-04
+> **Last Updated:** 2026-04-15
 
 ## Overview
 
@@ -17,130 +17,114 @@ graph TB
     Extension["DataGridUtils Extension<br/>Runs on: OutSystems Server"]
 
     %% External services
-    WijmoLib[Wijmo FlexGrid Library<br/>EXTERNAL]
-    OSPlatform[OutSystems Platform<br/>EXTERNAL]
+    WijmoLib[Wijmo FlexGrid v5.20252.44<br/>EXTERNAL]
     OSApp[OutSystems Reactive App<br/>EXTERNAL]
-    TestRepo[outsystems-datagrid-tests<br/>EXTERNAL]
 
     %% Communication flows
     OSApp -->|JavaScript API calls<br/>Synchronous| Browser
-    Browser -->|Uses grid provider<br/>Synchronous| WijmoLib
+    Browser -->|Wijmo FlexGrid API<br/>Synchronous| WijmoLib
     OSApp -->|Server Action calls<br/>Synchronous| Extension
     Extension -->|Returns JSON with metadata<br/>Synchronous| OSApp
-    Browser -->|Renders in DOM<br/>Synchronous| OSApp
-    TestRepo -->|WebDriver automation<br/>Synchronous| OSApp
+    Browser -->|DOM rendering<br/>Synchronous| OSApp
 
     %% Styling
     classDef thisRepo fill:#e0f2f1,stroke:#00796b,stroke-width:3px
     classDef external fill:#ffe1e1,stroke:#d32f2f,stroke-width:2px,stroke-dasharray: 5 5
 
     class Browser,Extension thisRepo
-    class WijmoLib,OSPlatform,OSApp,TestRepo external
+    class WijmoLib,OSApp external
 ```
 
 ## External Integrations
 
-| External Service          | Communication Type    | Purpose                                                                                                                                                       |
-| ------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Wijmo FlexGrid Library    | Sync (JavaScript API) | Third-party grid provider offering data virtualization, editing, filtering, sorting, grouping, export, and spreadsheet features via multi-panel architecture  |
-| OutSystems Platform       | Sync (Runtime APIs)   | Host platform executing server-side extensions and client-side blocks                                                                                         |
-| OutSystems Reactive App   | Sync (JavaScript API) | Consumer application instantiating and controlling grid instances via public API                                                                              |
-| outsystems-datagrid-tests | Sync (WebDriver HTTP) | External test automation repository validating grid behavior across browsers (Chrome, Firefox, Edge, Safari) and environments using WebdriverIO with Cucumber |
+| External Service | Communication Type | Purpose |
+|---|---|---|
+| Wijmo FlexGrid v5.20252.44 | Sync (JavaScript API) | Third-party grid provider offering data virtualization, editing, filtering, sorting, grouping, export, and multi-panel architecture |
+| OutSystems Reactive App | Sync (JavaScript API) | Consumer application instantiating and controlling grid instances via the `OutSystems.GridAPI` public API |
+| OutSystems Platform | Sync (Server Actions) | Host platform executing the .NET extension server-side and loading the compiled JS module client-side |
+| outsystems-datagrid-tests | Sync (WebDriver HTTP) | External test repository validating grid behavior across browsers via WebdriverIO + Cucumber |
 
 ## Architectural Tenets
 
 ### T1. Provider Abstraction Through Interfaces
 
-The framework defines all grid behavior through abstract interfaces and classes in the `OSFramework` namespace, completely isolating OutSystems-specific logic from provider implementation details. Wijmo-specific code resides exclusively in the `Providers` namespace and implements these contracts.
-
-**Rationale:** This abstraction enables swapping grid providers without modifying the OutSystems API surface or core grid logic. The framework layer remains stable while provider implementations can evolve independently.
+The framework defines all grid behavior through abstract interfaces and classes in the `OSFramework` namespace, completely isolating OutSystems-specific logic from provider implementation details. Wijmo-specific code resides exclusively in the `Providers` namespace and implements these contracts. This abstraction enables swapping grid providers without modifying the OutSystems API surface or core grid logic.
 
 **Evidence:**
-
 - `src/OSFramework/DataGrid/Grid/IGrid.ts` - defines grid contract without provider knowledge
 - `src/OSFramework/DataGrid/Column/AbstractColumn.ts` - base column behavior independent of provider
 - `src/Providers/DataGrid/Wijmo/Grid/FlexGrid.ts` (in `FlexGrid` class) - implements `AbstractGrid` with Wijmo provider
-- `src/Providers/DataGrid/Wijmo/Grid/Factory.ts` (in `GridFactory.MakeGrid` function) - provider factory creates concrete implementations
+- `src/Providers/DataGrid/Wijmo/Grid/Factory.ts` (in `GridFactory.MakeGrid`) - provider factory creates concrete implementations
+- `src/OSFramework/` - zero references to `Providers` namespace across all 146 files, confirming one-way dependency
 
 ### T2. Namespace-Based Layer Enforcement
 
-TypeScript namespaces (`OSFramework`, `Providers`, `OutSystems`) compile to a single AMD module without import statements. Layer boundaries are enforced by architectural convention: `OSFramework` must not reference `Providers` directly, and `Providers` implements `OSFramework` interfaces.
+TypeScript namespaces (`OSFramework`, `Providers`, `OutSystems`) compile to a single AMD module without ES6 import statements. Layer boundaries are enforced by architectural convention: `OSFramework` must not reference `Providers` directly, `Providers` implements `OSFramework` interfaces, and `OutSystems.GridAPI` orchestrates both layers through factories.
 
 **Rationale:** Namespace-based architecture with single-file compilation prevents circular dependencies and enforces unidirectional data flow. The API layer orchestrates, the framework defines contracts, and providers implement specifics.
 
 **Evidence:**
-
 - `tsconfig.json` - compiles all TypeScript to single AMD module `dist/GridFramework.js` via `outFile` option
-- `src/OSFramework/` directory - all 146 files declare `namespace OSFramework`, no references to `Providers` namespace found
-- `src/Providers/` directory - all 59 files declare `namespace Providers` and reference `OSFramework.DataGrid` interfaces
-- `src/OutSystems/GridAPI/GridManager.ts` (in `CreateGrid` function) - API layer calls through factory: `Providers.DataGrid.Wijmo.Grid.GridFactory.MakeGrid`
+- `src/OSFramework/` - all 146 files declare `namespace OSFramework`, no references to `Providers` namespace
+- `src/Providers/` - all 59 files declare `namespace Providers` and reference `OSFramework.DataGrid` interfaces
+- `src/OutSystems/GridAPI/GridManager.ts` (in `CreateGrid`) - API layer delegates to `Providers.DataGrid.Wijmo.Grid.GridFactory.MakeGrid`
 
 ### T3. Feature Composition Over Inheritance
 
-Grid capabilities (export, pagination, filtering, sorting, sanitization) are implemented as composable feature objects that each grid instance aggregates, rather than extending grid classes with feature methods.
+Grid capabilities (export, pagination, filtering, sorting, sanitization, etc.) are implemented as composable feature objects that each grid instance aggregates, rather than extending grid classes with feature methods. The `ExposedFeatures` class aggregates 31 feature properties, and the `FeatureBuilder` constructs all features via a fluent builder pattern.
 
 **Rationale:** Composition provides flexibility to enable/disable features dynamically and test features in isolation. Each feature encapsulates its own state and Wijmo event handlers without polluting the grid class.
 
 **Evidence:**
-
-- `src/OSFramework/DataGrid/Feature/` directory - contains interface definitions for all feature contracts (32 feature interface files)
-- `src/OSFramework/DataGrid/Feature/ExposedFeatures.ts` (in `ExposedFeatures` class) - aggregates 27 feature properties into single composable object
-- `src/Providers/DataGrid/Wijmo/Features/` directory - contains Wijmo-specific implementations of all features (32 implementation files)
-- `src/Providers/DataGrid/Wijmo/Features/FeatureBuilder.ts` (in `AbstractFactoryBuilder` class) - constructs feature instances via factory pattern
-- `src/OSFramework/DataGrid/Grid/AbstractGrid.ts` (in `AbstractGrid` class) - grid contains `_features` property of type `Feature.ExposedFeatures`
+- `src/OSFramework/DataGrid/Feature/ExposedFeatures.ts` (in `ExposedFeatures` class) - aggregates 31 feature properties into single composable object
+- `src/OSFramework/DataGrid/Feature/` - contains 31 feature interface definitions (`ICalculatedField`, `ICellData`, `IExport`, etc.)
+- `src/Providers/DataGrid/Wijmo/Features/FeatureBuilder.ts` (in `FeatureBuilder` class) - fluent builder constructs all feature instances via `_make*` methods
+- `src/OSFramework/DataGrid/Grid/AbstractGrid.ts` (in `AbstractGrid` class) - grid holds `_features` property of type `Feature.ExposedFeatures`
 
 ### T4. Data Transformation at Server Boundary
 
 Complex data preparation (OutSystems entity records to JSON with metadata extraction) occurs server-side via .NET extension before reaching the browser, keeping client-side code focused on presentation logic.
 
-**Rationale:** Server-side transformation leverages OutSystems runtime metadata and type information unavailable in the browser. This separation reduces client bundle size and computational load while ensuring type-safe data handling.
+**Rationale:** Server-side transformation leverages OutSystems runtime metadata and type information unavailable in the browser. This separation reduces client computational load and ensures type-safe data handling with proper date formatting and field-type metadata.
 
 **Evidence:**
-
-- `extension/DataGridUtils/Source/NET/DataGridUtils.cs` (in `MssConvertData2JSON` action) - converts OutSystems objects to JSON with embedded metadata
-- `extension/DataGridUtils/Source/NET/ObtainMetadata.cs` (in `getDataMetadata` method) - extracts column types and structure from .NET reflection
-- `src/OSFramework/DataGrid/Grid/AbstractDataSource.ts` - client-side only handles data binding and transformation
-- `src/OutSystems/GridAPI/GridManager.ts` (in `setDataInGrid` function) - receives pre-formatted JSON string from server
+- `extension/DataGridUtils/Source/NET/DataGridUtils.cs` (in `MssConvertData2JSON`) - converts OutSystems objects to JSON with embedded metadata
+- `extension/DataGridUtils/Source/NET/ObtainMetadata.cs` (in `getDataMetadata`) - extracts column types and structure from .NET reflection
+- `extension/DataGridUtils/Source/NET/temp_ardoJSON.cs` - forked JSON serializer handling OutSystems-specific date conventions
+- `src/OutSystems/GridAPI/GridManager.ts` (in `setDataInGrid`) - receives pre-formatted JSON string from server
 
 ### T5. Security Through Sanitization Layers
 
-Input sanitization occurs at two distinct boundaries: when data enters the grid from OutSystems (HTML escaping), and when data exits to clipboard/CSV export (formula injection prevention). The export sanitizer can be dynamically enabled or disabled at runtime.
+Input sanitization occurs at two distinct boundaries: when data enters the grid from OutSystems (HTML escaping), and when data exits to clipboard/CSV export (formula injection prevention). The export sanitizer can be dynamically enabled or disabled at runtime via the public API.
 
 **Rationale:** Defense-in-depth through multiple sanitization layers protects against distinct attack vectors (XSS via rendering, CSV injection via export) without coupling concerns. Each sanitization layer addresses specific threat models at appropriate system boundaries.
 
 **Evidence:**
-
-- `src/OSFramework/DataGrid/Helper/Sanitize.ts` (in `Sanitize` function) - escapes HTML angle brackets to prevent XSS when rendering user data
-- `src/OutSystems/GridAPI/GridManager.ts` (in `setDataInGrid` function) - conditionally sanitizes incoming data if `grid.config.sanitizeInputValues` is enabled
-- `src/Providers/DataGrid/Wijmo/Features/CellDataSanitizer.ts` (in `escapeCsvInjection` method) - neutralizes formula characters during clipboard/export operations
-- `src/OSFramework/DataGrid/Feature/ICellDataSanitizer.ts` - defines feature interface with `enableCellDataSanitizer` and `disableCellDataSanitizer` methods
+- `src/OSFramework/DataGrid/Helper/Sanitize.ts` (in `Sanitize` function) - replaces angle brackets with look-alike characters to prevent XSS when rendering user data
+- `src/OutSystems/GridAPI/GridManager.ts` (in `setDataInGrid`) - conditionally sanitizes incoming data when `grid.config.sanitizeInputValues` is enabled
+- `src/Providers/DataGrid/Wijmo/Features/CellDataSanitizer.ts` (in `escapeCsvInjection`) - neutralizes formula characters during clipboard/export operations
+- `src/OutSystems/GridAPI/Security.ts` (in `EnableCellDataSanitizer`/`DisableCellDataSanitizer`) - runtime toggle for CSV injection protection
 
 ## Component Boundaries
 
 ### Browser Runtime (TypeScript)
 
 **OutSystems API Layer** (`src/OutSystems/GridAPI/`)
-Exposes public JavaScript API consumed by OutSystems Reactive applications. Handles grid lifecycle, event subscriptions, and coordinates operations across framework and provider layers.
+Exposes public JavaScript API consumed by OutSystems Reactive applications. Handles grid lifecycle, event subscriptions, and coordinates operations across framework and provider layers. Includes performance instrumentation (`Performance/` subdirectory) wrapping all public API calls with timing marks.
 
 **Framework Layer** (`src/OSFramework/DataGrid/`)
 Provider-agnostic abstractions defining grid contracts, column types, events, features, and data source interfaces. Contains business logic independent of any specific grid library.
 
 **Provider Layer** (`src/Providers/DataGrid/Wijmo/`)
-Wijmo-specific implementations of framework interfaces. Directly interacts with `wijmo.grid.FlexGrid` library and translates between framework abstractions and Wijmo APIs. Leverages Wijmo's multi-panel architecture (data cells, column headers, row headers, footers) and row/column virtualization for performance with large datasets.
+Wijmo-specific implementations of framework interfaces. Directly interacts with `wijmo.grid.FlexGrid` library and translates between framework abstractions and Wijmo APIs. Leverages Wijmo's multi-panel architecture and row/column virtualization for performance with large datasets.
 
 ### Server Runtime (.NET)
 
-**DataGridUtils Extension** (`extension/DataGridUtils/`)
-OutSystems Integration Studio extension that converts OutSystems entity records and structures to JSON format with embedded metadata. Runs in OutSystems application server process.
+**DataGridUtils Extension** (`extension/DataGridUtils/Source/NET/`)
+OutSystems Integration Studio extension that converts OutSystems entity records and structures to JSON format with embedded metadata. Runs in OutSystems application server process. See `docs/adr/ADR-0001-Extension-Dotnet-Upgrade-And-Improvements.md` for .NET upgrade decisions.
 
 ## Build Process
 
 The TypeScript codebase compiles to a single AMD module (`dist/GridFramework.js`) that OutSystems applications load as a script resource. The .NET extension compiles to a DLL and deploys with OutSystems platform.
 
-**Common commands:**
-
-- `npm run build` - compile TypeScript, lint, and generate production artifacts
-- `npm run dev` - start development mode with live browser-sync on port 3000
-- `npm run setup` - install dependencies and start development mode
-
-See `gulpfile.js` for complete build orchestration.
+Run `npm run build` for production artifacts or `npm run dev` for browser-sync on port 3000. See `gulpfile.js` and `gulp/Tasks/` for build orchestration details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,158 +1,55 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+OutSystems Data Grid wraps Wijmo FlexGrid to deliver enterprise-grade spreadsheet functionality in OutSystems Reactive Web applications. The repository contains TypeScript (browser-side grid wrapper) and a .NET extension (server-side data preparation).
 
-## Overview
+## Foundation Documents
 
-OutSystems Data Grid wraps Wijmo FlexGrid to deliver enterprise-grade spreadsheet functionality in OutSystems Reactive Web applications. The repository contains TypeScript code (browser-side grid wrapper) and a .NET extension (server-side data preparation).
-
-See [ARCHITECTURE.md](./ARCHITECTURE.md) for the five architectural tenets and external integrations table.
-
-See [CONTRIBUTING.md](./.github/CONTRIBUTING.md) for branch naming (`ROU-12345`), PR requirements (2 approvals, label-based validation), and code standards.
-
-## Quick Command Reference
-
-| Command            | Purpose                                                               |
-| ------------------ | --------------------------------------------------------------------- |
-| `npm run setup`    | Install dependencies and start development mode                       |
-| `npm run build`    | Production build + lintfix + lint (must pass without errors/warnings) |
-| `npm run dev`      | Start development mode with browser-sync on port 3000                 |
-| `npm run lint`     | Check TypeScript code style (ESLint)                                  |
-| `npm run lintfix`  | Auto-fix ESLint issues                                                |
-| `npm run prettier` | Format all JS/TS/CSS files                                            |
-| `npm run docs`     | Generate TypeDoc documentation                                        |
-
-## Repository Structure
-
-```
-src/
-├── OSFramework/DataGrid/    - Provider-agnostic abstractions (interfaces, events, features)
-├── Providers/DataGrid/Wijmo/ - Wijmo-specific implementations
-├── OutSystems/GridAPI/       - Public JavaScript API for OutSystems apps
-└── @types/wijmo-5.20252.44/  - Wijmo type definitions
-
-extension/DataGridUtils/
-├── Source/NET/               - .NET extension implementation (edit here)
-├── Templates/NET/            - Auto-generated Integration Studio stubs (do not edit)
-└── tests/                    - Standalone .NET test project
-
-gulp/                         - Build orchestration tasks
-dist/                         - Compiled output (GridFramework.js)
-docs/adr/                     - Architecture Decision Records
-```
-
-Run `find src/OSFramework/DataGrid -type f -name "*.ts"` to explore framework layer files.
-Run `find src/Providers/DataGrid/Wijmo -type f -name "*.ts"` to explore Wijmo provider files.
-
-## TypeScript Architecture
-
-**Namespace-based layer boundaries:** The codebase compiles all TypeScript to a single AMD module (`dist/GridFramework.js`) without ES6 imports. Namespace hierarchy enforces layer separation:
-
-- `OutSystems.GridAPI` - Public API layer; orchestrates grid lifecycle
-- `OSFramework.DataGrid` - Framework abstractions; provider-agnostic contracts
-- `Providers.DataGrid.Wijmo` - Wijmo-specific implementations
-
-See [ARCHITECTURE.md](./ARCHITECTURE.md) T1 (provider abstraction through interfaces) and T2 (namespace-based layer enforcement).
-
-**Feature composition:** Grid capabilities (export, pagination, filtering, sorting, sanitization) are implemented as composable feature objects aggregated by `OSFramework.DataGrid.Feature.ExposedFeatures` rather than extending grid classes. See [ARCHITECTURE.md](./ARCHITECTURE.md) T3.
-
-**Key patterns:**
-
-- Factory: `Providers.DataGrid.Wijmo.Grid.GridFactory.MakeGrid` creates concrete grid instances
-- Abstract base classes: `OSFramework.DataGrid.Column.AbstractColumn` defines column behavior independent of provider
-- Interface contracts: `OSFramework.DataGrid.Grid.IGrid` defines grid API without provider knowledge
+- [ARCHITECTURE.md](./ARCHITECTURE.md) — five architectural tenets (T1–T5), component boundaries, external integrations table, and build process
+- [CONTRIBUTING.md](./.github/CONTRIBUTING.md) — branch naming (`ROU-12345`), PR title/label requirements, code standards (naming conventions, member ordering, formatting), and getting help
 
 ## .NET Extension Context
 
-The DataGridUtils extension converts OutSystems entities/structures to JSON with embedded metadata.
+The DataGridUtils extension converts OutSystems entities/structures to JSON with embedded metadata. Key files live under `extension/DataGridUtils/Source/NET/`:
 
-**Key files under `extension/DataGridUtils/Source/NET/`:**
+- `Interface.cs` — public API (`IssDataGridUtils.MssConvertData2JSON`)
+- `DataGridUtils.cs` — bundles data + metadata into `{"data": ..., "metadata": ...}`
+- `ObtainMetadata.cs` — reflection-based schema extraction
+- `temp_ardoJSON.cs` — forked JSON serializer with smart ISO 8601 date handling
 
-- `Interface.cs` - Public API (`IssDataGridUtils.MssConvertData2JSON`)
-- `DataGridUtils.cs` - Implementation; bundles data + metadata into `{"data": ..., "metadata": ...}`
-- `ObtainMetadata.cs` - Reflection-based schema extraction
-- `temp_ardoJSON.cs` - Forked JSON serializer with smart ISO 8601 dates
+**OutSystems field prefix conventions** (stripped in JSON output):
+- `ss` — simple field, `ssEN` — entity, `ssST` — structure
+- `Byte[]` fields are excluded from both data and metadata
+- DateTime: `1900-01-01 00:00:00` → empty string, date-only → `yyyy-MM-dd`, full → UTC ISO 8601
 
-**Testing:** Run tests from `extension/tests/DataGridUtils.Tests.csproj` (console app with mock OutSystems types).
-
-**Conventions:**
-
-- OutSystems fields use `ss` prefix (simple), `ssEN` (entity), `ssST` (structure) — stripped in JSON output
-- `Byte[]` fields excluded from data and metadata
-- DateTime format: `1900-01-01 00:00:00` → empty string, date-only → `yyyy-MM-dd`, full → UTC ISO 8601
+**Testing:** Run console tests from `extension/tests/DataGridUtils.Tests.csproj` (mock OutSystems types).
 
 See `.cursor/rules/project-context.mdc` for detailed extension context.
 
-## Code Style (Enforced by ESLint)
-
-**Naming conventions:**
-
-- Exported functions/classes: `StrictPascalCase`
-- Interfaces: `IStrictPascalCase` or `IUPPER_CASE` (prefix with `I`)
-- Private properties/methods: `_strictCamelCase` (leading underscore required)
-- Public/protected properties/methods: `strictCamelCase` (no underscore)
-
-**Member ordering in classes:** signature → private fields → protected fields → public fields → constructor → private methods → protected methods → public methods → abstract methods (alphabetically within each category)
-
-**Formatting:** Tabs (width 4), single quotes, semicolons required, 120 char line width.
-
-Run `npm run lintfix` to auto-fix style issues before committing.
-
 ## Wijmo Provider Context
 
-This codebase wraps Wijmo FlexGrid (external library). Key Wijmo capabilities leveraged:
+When modifying provider layer code (`src/Providers/DataGrid/Wijmo/`), consult Wijmo FlexGrid docs at https://developer.mescius.com/wijmo/api/classes/Wijmo_Grid.Flexgrid.html. Key Wijmo capabilities used:
 
-- **Virtual rendering** - Fast display of large datasets via row/column virtualization
-- **Multi-panel architecture** - Separate panels for data cells, column headers, row headers, footers
-- **itemsSource/collectionView** - Data binding with currency tracking and editing support
-- **Selection API** - Cell ranges, row selection via `selection`, `selectedItems`, `selectedRows`
-- **Editing lifecycle** - `startEditing`, `finishEditing`, `itemValidator` for validation
-- **Clipboard operations** - `getClipString`, `copied`, `pasted` events
+- Virtual rendering (row/column virtualization for large datasets)
+- Multi-panel architecture (data cells, column headers, row headers, footers)
+- `itemsSource`/`collectionView` for data binding with editing support
+- Selection API (`selection`, `selectedItems`, `selectedRows`)
+- Editing lifecycle (`startEditing`, `finishEditing`, `itemValidator`)
+- Clipboard events (`getClipString`, `copied`, `pasted`)
 
-When modifying provider layer code (`src/Providers/DataGrid/Wijmo/`), consult Wijmo FlexGrid documentation at https://developer.mescius.com/wijmo/api/classes/Wijmo_Grid.Flexgrid.html for API details.
+## Security Boundaries
 
-## Important Context
+Input sanitization occurs at two distinct points — see [ARCHITECTURE.md](./ARCHITECTURE.md) T5 for rationale:
 
-**Security boundaries:** Input sanitization occurs at two distinct points:
+1. **Data entry** — HTML escaping via `OSFramework.DataGrid.Helper.Sanitize`
+2. **Data exit** — CSV injection prevention via `Providers.DataGrid.Wijmo.Features.CellDataSanitizer`
 
-1. When data enters grid from OutSystems - HTML escaping (`OSFramework.DataGrid.Helper.Sanitize`)
-2. When data exits via clipboard/export - CSV injection prevention (`Providers.DataGrid.Wijmo.Features.CellDataSanitizer`)
+Runtime toggles: `OutSystems.GridAPI.Security.EnableCellDataSanitizer(gridID)` / `DisableCellDataSanitizer(gridID)`
 
-The cell data sanitizer feature can be controlled at runtime via the public API:
+## Do Not Modify
 
-- `OutSystems.GridAPI.Security.EnableCellDataSanitizer(gridID)` - Enable CSV injection protection
-- `OutSystems.GridAPI.Security.DisableCellDataSanitizer(gridID)` - Disable CSV injection protection
+- `extension/DataGridUtils/Templates/NET/` — auto-generated by Integration Studio
+- `src/@types/wijmo-5.20252.44/` — vendored Wijmo type definitions
 
-See [ARCHITECTURE.md](./ARCHITECTURE.md) T5 (security through sanitization layers) for defense-in-depth rationale.
+## ADRs
 
-**Data transformation strategy:** Complex data preparation (OutSystems records → JSON with metadata) happens server-side via .NET extension before reaching browser. Client-side code focuses on presentation logic. See [ARCHITECTURE.md](./ARCHITECTURE.md) T4.
-
-**Branch strategy:** Work on `dev` branch. Create feature branches named `ROU-12345` (JIRA ticket ID). Commits must include ticket ID: `ROU-12345: Add feature description`.
-
-**PR requirements:** Title format `ROU-12345: Description`, must have label (`feature`/`bug`/`chore`), 1 approval required. See [CONTRIBUTING.md](./.github/CONTRIBUTING.md) for complete PR process and label requirements.
-
-**ADRs available:** See `docs/adr/` for Architecture Decision Records. Currently documented: ADR-0001 (Extension .NET Upgrade).
-
-**Test automation:** The grid has a separate test repository at https://github.com/OutSystems/outsystems-datagrid-tests (WebdriverIO + Cucumber for browser testing). It's checked out locally at `../outsystems-datagrid-tests`. See [CONTRIBUTING.md](./.github/CONTRIBUTING.md) for testing context.
-
-## Development Workflow
-
-1. Check out branch from `dev`: `git checkout -b ROU-12345`
-2. Make changes to TypeScript (`src/`) or .NET (`extension/DataGridUtils/Source/NET/`)
-3. For TypeScript: Run `npm run build` (must pass without errors/warnings)
-4. For .NET: Open `DataGridUtils.sln` in `extension/DataGridUtils/Source/NET/` with Visual Studio, build targeting .NET Framework 4.7.2
-5. Test locally (TypeScript: `npm run dev` starts browser-sync; .NET: run console tests)
-6. Create PR to `dev` with JIRA ticket ID in title
-
-**Do not modify:**
-
-- `extension/DataGridUtils/Templates/NET/` - Auto-generated by Integration Studio
-- Wijmo library files in `@types/wijmo-5.20252.44/`
-
-## Useful Resources
-
-- **Living documentation:** https://outsystemsui.outsystems.com/OutSystemsDataGridSample/
-- **Forge component - O11:** https://www.outsystems.com/forge/component-overview/9764/outsystems-data-grid-o11
-- **Forge component - ODC:** https://www.outsystems.com/forge/component-overview/15929/outsystems-data-grid-odc
-- **Sample app:** https://www.outsystems.com/forge/component-overview/9765/data-grid-sample-reactive
-- **Video tutorial:** https://www.youtube.com/watch?v=OFXOPrkRlrI
+Architecture Decision Records in `docs/adr/`. Currently: ADR-0001 (Extension .NET Upgrade).

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-remove-empty-lines": "^0.1.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-typescript": "^6.0.0-alpha.1",
+    "lodash": "4.17.23",
     "postcss": "^8.5.6",
     "postcss-discard-comments": "^5.1.2",
     "postcss-discard-duplicates": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "UI Components"
   ],
   "devDependencies": {
-    "@types/lodash": "^4.17.23",
+    "@types/lodash": "^4.17.24",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "browser-sync": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp-remove-empty-lines": "^0.1.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-typescript": "^6.0.0-alpha.1",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "postcss": "^8.5.6",
     "postcss-discard-comments": "^5.1.2",
     "postcss-discard-duplicates": "^5.1.0",


### PR DESCRIPTION
### What was done
* This pull request makes a minor update to the `@types/lodash` development dependency in the `package.json` file, upgrading it from version 4.17.23 to 4.17.24.
* This was required to fix [CVE-2025-13465](https://nvd.nist.gov/vuln/detail/CVE-2025-13465).

### Test Steps
- Ran tests pipeline


### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

