### PR TITLE
ROU-12739: Fix issue that caused an error when pasting a value in multiple cells

### DIFF
--- a/docs/adr/ADR-0004-ValidationMark-Column-Group-Index-Collision-Fix.md
+++ b/docs/adr/ADR-0004-ValidationMark-Column-Group-Index-Collision-Fix.md
@@ -1,0 +1,67 @@
+# ADR-0004: Fix Column-Group Index Collision in ValidationMark Cell Edit Handler
+
+## Status
+
+Accepted
+
+## Context
+
+Wijmo FlexGrid maintains data columns and column groups in **separate internal arrays**, each using its own zero-based index sequence. A `ColumnGroup` at position 0 in the groups array and a regular `Column` at position 0 in the columns array therefore share the same `index` value, but they refer to entirely different things.
+
+On the OutSystems side, `grid.getColumns()` returns all column-like objects — both `ColumnType.Group` entries and real data columns — in a single mixed array. The `ValidationMark._cellEditEndedHandler` was resolving which OS column was edited by doing:
+
+```typescript
+const OSColumn = this._grid.getColumns().find((item) => item.provider.index === column.index);
+```
+
+Without pre-filtering, a `ColumnType.Group` entry could satisfy `provider.index === column.index` before the actual data column was reached, causing `OSColumn` to be resolved as a group instead of the edited column. The group's `uniqueId` was then passed to `_triggerEventsFromColumn`, which retrieved the group via `getColumn()` and called `_handleOnCellChangeEvent` on it. Accessing `column.hasEvents` on a group column delegates to the `columnEvents` getter, which is explicitly unsupported and throws:
+
+```
+Uncaught Error: The column Group does not support events
+    at get columnEvents (GridFramework.js)
+    at get hasEvents (GridFramework.js)
+    at ValidationMark._handleOnCellChangeEvent (GridFramework.js)
+    at ValidationMark._triggerEventsFromColumn (GridFramework.js)
+    at ValidationMark._cellEditEndedHandler (GridFramework.js)
+```
+
+This exception surfaced in the browser console on every cell edit in grids that contained column groups, and silently prevented the `OnCellValueChange` event from reaching the OutSystems application.
+
+## Decision Drivers
+
+-   Grids that use column groups must fire validation and `OnCellValueChange` events correctly on cell edits.
+-   The column lookup must be stable regardless of how many groups or columns are present and in what order `getColumns()` returns them.
+-   The fix must not change the contract for grids without groups.
+
+## Considered Options
+
+-   **Filter out groups before the index lookup (chosen)** — Add `.filter((item) => item.columnType !== ColumnType.Group)` before `.find()`, then guard the trigger call with `if (OSColumn !== undefined)`.
+
+    -   Pros: minimal change, directly addresses the ambiguity at its source, no impact on undo/redo paths or other call sites.
+    -   Cons: the undo/redo handlers (`_undoActionHandler`, `_redoActionHandler`) still do the unfiltered lookup; those paths are lower-risk because undo actions carry a column index from a prior edit that already resolved correctly, but they are a latent concern.
+
+-   **Look up by column binding instead of index** — Resolve the OS column via `column.binding` rather than `column.index`.
+    -   Pros: bindings are unique and unambiguous; avoids the index-sharing problem entirely.
+    -   Cons: requires verifying that bindings are always populated and consistent across all column types and call sites, which is a broader refactor out of scope for this fix. Besides that there can be multiple columns with the same binding.
+
+## Decision Outcome
+
+The `.filter()` guard was applied in `_cellEditEndedHandler` so only non-Group columns participate in the index comparison. An explicit `if (OSColumn !== undefined)` check was added before accessing `.uniqueId`, preventing a runtime exception if the lookup still yields no match for any other unforeseen reason.
+
+Positive consequences:
+
+-   `OnCellValueChange` and mandatory-field validation events fire correctly in grids that contain column groups.
+-   No behavioral change for grids without column groups.
+
+Negative consequences:
+
+-   None identified.
+
+## Links
+
+-   `src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts` — `_cellEditEndedHandler` method, lines 42–60.
+-   Jira ticket: ROU-12739.
+
+## Date
+
+2026-05-12

--- a/docs/adr/ADR-0004-ValidationMark-Column-Group-Index-Collision-Fix.md
+++ b/docs/adr/ADR-0004-ValidationMark-Column-Group-Index-Collision-Fix.md
@@ -37,8 +37,8 @@ This exception surfaced in the browser console on every cell edit in grids that 
 
 -   **Filter out groups before the index lookup (chosen)** — Add `.filter((item) => item.columnType !== ColumnType.Group)` before `.find()`, then guard the trigger call with `if (OSColumn !== undefined)`.
 
-    -   Pros: minimal change, directly addresses the ambiguity at its source, no impact on undo/redo paths or other call sites.
-    -   Cons: the undo/redo handlers (`_undoActionHandler`, `_redoActionHandler`) still do the unfiltered lookup; those paths are lower-risk because undo actions carry a column index from a prior edit that already resolved correctly, but they are a latent concern.
+    -   Pros: minimal change, directly addresses the ambiguity at its source, no impact on undo/redo paths or other call sites. The same fix, is to be applied in all the undo/redo handlers (`_undoActionHandler`, `_redoActionHandler`).
+    -   Cons: none known.
 
 -   **Look up by column binding instead of index** — Resolve the OS column via `column.binding` rather than `column.index`.
     -   Pros: bindings are unique and unambiguous; avoids the index-sharing problem entirely.

--- a/docs/adr/ADR-0004-ValidationMark-Column-Group-Index-Collision-Fix.md
+++ b/docs/adr/ADR-0004-ValidationMark-Column-Group-Index-Collision-Fix.md
@@ -41,8 +41,8 @@ This exception surfaced in the browser console on every cell edit in grids that 
     -   Cons: none known.
 
 -   **Look up by column binding instead of index** — Resolve the OS column via `column.binding` rather than `column.index`.
-    -   Pros: bindings are unique and unambiguous; avoids the index-sharing problem entirely.
-    -   Cons: requires verifying that bindings are always populated and consistent across all column types and call sites, which is a broader refactor out of scope for this fix. Besides that there can be multiple columns with the same binding.
+    -   Pros: avoids the specific index-sharing collision between column groups and data columns, and may better reflect the data field being edited.
+    -   Cons: requires verifying that bindings are always populated, consistent across all column types and call sites, and unique enough for this lookup to be reliable. In some configurations, multiple columns may share the same binding, so this is a broader refactor out of scope for this fix.
 
 ## Decision Outcome
 

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -170,9 +170,15 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			) {
 				const binding = this._grid.provider.getColumn(action.col).binding;
 
-				const OSColumn = this._grid.getColumns().find((item) => item.provider.index === action.col);
-				const oldValue = this._grid.features.dirtyMark.getOldValue(action.row, binding);
-				this._triggerEventsFromColumn(action.row, OSColumn.uniqueId, oldValue, action._newState);
+				const OSColumn = this._grid
+					.getColumns()
+					.filter((item) => item.columnType !== OSFramework.DataGrid.Enum.ColumnType.Group)
+					.find((item) => item.provider.index === action.col);
+
+				if (OSColumn !== undefined) {
+					const oldValue = this._grid.features.dirtyMark.getOldValue(action.row, binding);
+					this._triggerEventsFromColumn(action.row, OSColumn.uniqueId, oldValue, action._newState);
+				}
 			}
 		}
 
@@ -300,9 +306,13 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			) {
 				const binding = this._grid.provider.getColumn(action.col).binding;
 				const oldValue = this._grid.features.dirtyMark.getOldValue(action.row, binding);
-				const OSColumn = this._grid.getColumns().find((item) => item.provider.index === action.col);
-
-				this._triggerEventsFromColumn(action.row, OSColumn.uniqueId, oldValue, action._oldState);
+				const OSColumn = this._grid
+					.getColumns()
+					.filter((item) => item.columnType !== OSFramework.DataGrid.Enum.ColumnType.Group)
+					.find((item) => item.provider.index === action.col);
+				if (OSColumn !== undefined) {
+					this._triggerEventsFromColumn(action.row, OSColumn.uniqueId, oldValue, action._oldState);
+				}
 			}
 		}
 

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -41,11 +41,22 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
 			if (isNewValue) {
 				const column = s.getColumn(e.col);
-				const OSColumn = this._grid.getColumns().find((item) => item.provider.index === column.index);
 
-				// The old value can be captured on the dirtyMark feature as it is the one responsible for saving the original values
-				const oldValue = this._grid.features.dirtyMark.getOldValue(e.row, column.binding);
-				this._triggerEventsFromColumn(e.row, OSColumn.uniqueId, oldValue, newValue);
+				// The provider stores the columns and the groups in different arrays, so, in order to compare the
+				// column index, we need to make sure we are comparing with the columns and not with groups.
+				// It can occur that groups can have the same index as columns, however on OutSystems side, the
+				// columns and groups are mixed in the same array.
+				const OSColumn = this._grid
+					.getColumns()
+					// Let's only return columns that are not Group type.
+					.filter((item) => item.columnType !== OSFramework.DataGrid.Enum.ColumnType.Group)
+					.find((item) => item.provider.index === column.index);
+
+				if (OSColumn !== undefined) {
+					// The old value can be captured on the dirtyMark feature as it is the one responsible for saving the original values
+					const oldValue = this._grid.features.dirtyMark.getOldValue(e.row, column.binding);
+					this._triggerEventsFromColumn(e.row, OSColumn.uniqueId, oldValue, newValue);
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR fixes a misbehavior that caused an error, when the grid had GroupColumns and a cell or group of cells where edited. The fix ensures that only true data columns are considered during event resolution, preventing accidental selection of group columns and restoring correct event firing for cell edits, undo, and redo actions.

### What was happening
* An error was occasionally occurring when a cell was edited, and the grid uses `GroupColumns`;
* The cause was identified as being a mismatch of how `Column`s / `GroupColumn`s are stored in the provider and in the internal OutSystems Framework that:
   * In the provider, the  `Column`s and `GroupColumn`s are stored in different arrays;
   * In the internal OutSystems Framework, both `Column`s and `GroupColumn`s are stored in the same array;

### What was done
* Updated the `_cellEditEndedHandler`, `_undoActionHandler`, and `_redoActionHandler` methods in `ValidationMark.ts` to filter out group columns before matching by index, ensuring only non-group columns are considered when resolving the edited column. This prevents runtime errors and ensures events like `OnCellValueChange` fire correctly in grids with column groups.
* Added ADR-0004 to document the context, decision, and outcome of the column-group index collision fix, including technical reasoning, trade-offs, and links to the affected code and Jira ticket.

### Screenshots

#### Before
<img width="1901" height="946" alt="datagrid-error-group-edit" src="https://github.com/user-attachments/assets/3557faf7-299f-426e-a588-299c4887e3be" />

#### After the fix
<img width="1900" height="946" alt="datagrid-error-group-edit-fix" src="https://github.com/user-attachments/assets/47e55c5f-e14b-4734-a45f-85bf4bc61e8d" />

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

