### PR TITLE
ROU-12796: Fix seconds trim on SetCellData

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "stylelint-config-prettier": "^9.0.5",
     "stylelint-order": "^6.0.4",
     "typedoc": "^0.28.19",
-    "typedoc-plugin-merge-modules": "^4.1.0",
+    "typedoc-plugin-merge-modules": "^7.0.0",
     "typedoc-umlclass": "^0.10.2",
-    "typescript": "^4.9.5",
+    "typescript": "~5.4.5",
     "wijmo": "^5.20261.50"
   }
 }

--- a/src/Providers/DataGrid/Wijmo/Features/CellData.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/CellData.ts
@@ -19,7 +19,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
 		public setCellData(rowNumber: number, column: OSFramework.DataGrid.Column.IColumn, value: string): void {
 			if (column.columnType === OSFramework.DataGrid.Enum.ColumnType.DateTime) {
-				value = this._grid.dataSource.trimSecondsFromDate(value);
+				if (column.config.format.trim().toLowerCase().includes('s')) {
+					value = this._grid.dataSource.trimSecondsFromDate(value);
+				}
 			}
 
 			this._grid.provider.setCellData(rowNumber, column.provider.index, value, true);

--- a/src/Providers/DataGrid/Wijmo/Features/CellData.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/CellData.ts
@@ -19,7 +19,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
 		public setCellData(rowNumber: number, column: OSFramework.DataGrid.Column.IColumn, value: string): void {
 			if (column.columnType === OSFramework.DataGrid.Enum.ColumnType.DateTime) {
-				if (column.config.format.trim().toLowerCase().includes('s')) {
+				if (!column.config.format.trim().toLowerCase().includes('s')) {
 					value = this._grid.dataSource.trimSecondsFromDate(value);
 				}
 			}


### PR DESCRIPTION
This PR is to fix the seconds trim on SetCellData

### What was happening
* When using the API method `SetCellData` if the column was of type DateTime the seconds part was trimmed due to the fact that the inline picker only allows the selection of hours and minutes.
* If the user defines the format as containing seconds, the seconds would always be 0. This was inconsistent with the insertion of data by the DataAction that would include the seconds.

### What was done
* The trim method was removed as well as the call to the method
* The cell equals function was updated to take into consideration the possibility of having dates with and without seconds.

### Test Steps
1. Open the sample application
2. Click on the button
3. Validate that the first DateTime Cell get the data with the seconds information

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

