### PR TITLE
ROU-12864: Add new parameter to SetCellData client action

### DIFF
--- a/src/OSFramework/DataGrid/Feature/ICellData.ts
+++ b/src/OSFramework/DataGrid/Feature/ICellData.ts
@@ -12,7 +12,8 @@ namespace OSFramework.DataGrid.Feature {
 			rowNumber: number,
 			column: OSFramework.DataGrid.Column.IColumn,
 			// eslint-disable-next-line
-			value: string
+			value: string,
+			valueIsKey: boolean
 		): void;
 	}
 }

--- a/src/OutSystems/GridAPI/Cell.ts
+++ b/src/OutSystems/GridAPI/Cell.ts
@@ -106,7 +106,8 @@ namespace OutSystems.GridAPI.Cells {
 		// eslint-disable-next-line
 		value: any,
 		showDirtyMark = true,
-		triggerOnCellValueChange = true
+		triggerOnCellValueChange = true,
+		valueIsKey = false
 	): string {
 		Performance.SetMark('Cells.setCellData');
 
@@ -124,7 +125,7 @@ namespace OutSystems.GridAPI.Cells {
 				if (showDirtyMark) {
 					grid.features.dirtyMark.saveOriginalValue(rowIndex, column.providerIndex);
 				}
-				grid.features.cellData.setCellData(rowIndex, column, value);
+				grid.features.cellData.setCellData(rowIndex, column, value, valueIsKey);
 				grid.features.validationMark.validateCell(rowIndex, column, triggerOnCellValueChange);
 			},
 		});

--- a/src/OutSystems/GridAPI/Cell.ts
+++ b/src/OutSystems/GridAPI/Cell.ts
@@ -98,6 +98,7 @@ namespace OutSystems.GridAPI.Cells {
 	 * @param {*} value New value to settled on the cell.
 	 * @param {boolean} [showDirtyMark=true] Boolean that represents if the action should also show a dirty mark.
 	 * @param {boolean} [triggerOnCellValueChange=true] Boolean that represents if we want to trigger the on value change event or not
+	 * @param {boolean} [valueIsKey=false] Boolean that represents if the value is already a key value of dataMap
 	 */
 	export function SetCellData(
 		gridID: string,

--- a/src/Providers/DataGrid/Wijmo/Features/CellData.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/CellData.ts
@@ -23,7 +23,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					value = this._grid.dataSource.trimSecondsFromDate(value);
 				}
 			}
-
+			// Calls the cells setCellData method to update the cell value
+			// The cells setCellData method is prefered since it allows us to pass a parameter to indicate if the value is a key value of dataMap
 			this._grid.provider.cells.setCellData(rowNumber, column.provider.index, value, true, true, valueIsKey);
 		}
 	}

--- a/src/Providers/DataGrid/Wijmo/Features/CellData.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/CellData.ts
@@ -17,14 +17,14 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			//
 		}
 
-		public setCellData(rowNumber: number, column: OSFramework.DataGrid.Column.IColumn, value: string): void {
+		public setCellData(rowNumber: number, column: OSFramework.DataGrid.Column.IColumn, value: string, valueIsKey: boolean): void {
 			if (column.columnType === OSFramework.DataGrid.Enum.ColumnType.DateTime) {
 				if (!column.config.format.trim().toLowerCase().includes('s')) {
 					value = this._grid.dataSource.trimSecondsFromDate(value);
 				}
 			}
 
-			this._grid.provider.setCellData(rowNumber, column.provider.index, value, true);
+			this._grid.provider.cells.setCellData(rowNumber, column.provider.index, value, true, true, valueIsKey);
 		}
 	}
 }


### PR DESCRIPTION
This PR is to add a new parameter to SetCellData Client Action to consider the value as a key

### What was happening
* The SetCellData Client Action was considering that the value could be the key or the value.
* This made the internal Wijmo logic look for a key with the value passed as a parameter.
* In some cases, the key could be used as a value and trigger a search for other options

### What was done
* A new parameter was added to the API function
* The internal call is now done to a different function with the same behaviour that allow to pass a parameter to directly consider the value passed as an `option key`

### Test Steps
1. Open the sample application
2. Click on the "Set 3" button
3. Validate that the text "Option3" is presented

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

