### PR TITLE
ROU-11724: Update TypeScript and Typedoc to use the latest stable versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ new-version-artf.txt
 # Distribution files folder
 dist/**
 
+# Generated TypeDoc output (keep ADRs)
+docs/*
+!docs/adr/
+
 # Extension compiled files
 /**/Bin/**
 /**/obj/**

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typedoc": "^0.28.19",
     "typedoc-plugin-merge-modules": "^7.0.0",
     "typedoc-umlclass": "^0.10.2",
-    "typescript": "~5.4.5",
+    "typescript": "^5.9.3",
     "wijmo": "^5.20261.50"
   },
   "volta": {

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,11 +5,43 @@
         "./src/Providers/DataGrid/**/*.ts"
     ],
     "entryPointStrategy": "expand",
+    "plugin": [
+        "typedoc-umlclass",
+        "typedoc-plugin-merge-modules"
+    ],
     "includeVersion": true,
     "hideGenerator": true,
     "out": "./docs",
     "sort": [
         "source-order"
+    ],
+    "blockTags": [
+        "@alpha",
+        "@beta",
+        "@defaultValue",
+        "@deprecated",
+        "@example",
+        "@experimental",
+        "@internal",
+        "@override",
+        "@param",
+        "@privateRemarks",
+        "@public",
+        "@remarks",
+        "@returns",
+        "@sealed",
+        "@see",
+        "@throws",
+        "@virtual",
+        "@memberof",
+        "@export",
+        "@static",
+        "@todo",
+        "@return",
+        "@extends",
+        "@template",
+        "@type",
+        "@implements"
     ],
     "umlClassDiagram": {
         "type": "detailed",
@@ -21,4 +53,9 @@
         "arrowColor": "#272b30"
     },
     "customCss": "typedoc-custom.css",
+    "validation": {
+        "notExported": false,
+        "invalidLink": true,
+        "notDocumented": false
+    }
 }


### PR DESCRIPTION
### What was done
* update typescript, typedoc and its plugins;

### Test Steps
1. Run npm run docs and check there are no errors.

### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

