### PR TITLE
ROU-12889: Fix an issue that kept the invalid cell marked as invalid

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -88,6 +88,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
 				wijmo.addClass(e.cell, 'wj-state-invalid');
 			} else if (e.panel.cellType === wijmo.grid.CellType.RowHeader && this._isInvalidRowByRowNumber(e.row)) {
 				wijmo.addClass(e.cell, 'wj-state-invalid');
+			} else {
+				wijmo.removeClass(e.cell, 'wj-state-invalid');
 			}
 		}
 
@@ -311,6 +313,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					.filter((item) => item.columnType !== OSFramework.DataGrid.Enum.ColumnType.Group)
 					.find((item) => item.provider.index === action.col);
 				if (OSColumn !== undefined) {
+					this.setCellStatus(action.row, OSColumn.widgetId, true, '', true);
 					this._triggerEventsFromColumn(action.row, OSColumn.uniqueId, oldValue, action._oldState);
 				}
 			}


### PR DESCRIPTION
This PR fixes an issue that kept the invalid cell marked as invalid

[Sample page](url)

### What was happening
* If a cell was marked as invalid and the user does an undo, the invalid mark keeps appearing even if the value is valid

### What was done
* A reevaluation of the values is done after an undo, and the invalid class is removed if the value is no longer invalid

### Test Steps
1. Open the sample application
2. Change the `Price` in the second row to a value lower than 90
3. Validate that the cell is marked as invalid
4. Do Ctrl+z or Cmd+z
5. Validate that the invalid mark disappears 

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

