### PR TITLE
ROU-12855: V2 Resolve Github Actions deprecation warnings for Node 20

### DIFF
--- a/.github/actions/az-keyvault-get/action.yml
+++ b/.github/actions/az-keyvault-get/action.yml
@@ -65,16 +65,14 @@ inputs:
 outputs:
     az-keyvault-value:
         description: 'The Azure key value.'
-        value: ${{ steps.GetAzKeyVaultSecret.outputs.az-keyvault-secret }}
+        value: ${{ steps.GetAzKeyVaultSecret.outputs.az-keyvault-value }}
 
 runs:
     using: composite
     steps:
         - name: Azure KeyVault get Value
-          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+          uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
           id: GetAzKeyVaultSecret
           with:
-              inlineScript: |
-                  secretValue=$(az keyvault secret show --name "${{ inputs.key-name }}" --vault-name "${{ inputs.keyvault-name }}" --query "value" --output tsv)
-                  echo "::add-mask::$secretValue"
-                  echo "az-keyvault-secret=$secretValue" >> $GITHUB_OUTPUT
+              keyvault-name: ${{ inputs.keyvault-name }}
+              key-name: ${{ inputs.key-name }}

--- a/.github/actions/az-login/action.yml
+++ b/.github/actions/az-login/action.yml
@@ -43,7 +43,7 @@ runs:
     using: composite
     steps:
         - name: Azure DevOps Login
-          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+          uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
           with:
               client-id: ${{ inputs.client-id }}
               tenant-id: ${{ inputs.tenant-id }}

--- a/.github/actions/validate-pr-title/action.yml
+++ b/.github/actions/validate-pr-title/action.yml
@@ -37,7 +37,7 @@ runs:
   using: composite
   steps:
     - name: "Check PR title follows '${{ inputs.validate-semVer == true && '+semver: <minor|major|patch> ' || '' }}<ticket id> <description>'"
-      uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 #v1.0.2
+      uses: OutSystems/rd.github-reusable-workflows/.github/actions/validate-pr-title@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
       with:
-        regex: ^${{ inputs.validate-semVer == true && '(\+semver:\s(minor|major|patch)\s)?' || '' }}([A-Z][A-Z0-9]*-\d+(:)?\s\w)
+        validate-semVer: ${{ inputs.validate-semVer }}
       if: ${{ contains(github.head_ref, 'release/') == false && contains(github.head_ref, 'merge/') == false }}


### PR DESCRIPTION
### What was done
* update rd.github-reusable-workflows usage;
* remove direct third party actions and use the one from rd.github-reusable-workflows;


### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

