### PR TITLE
ROU-12891: Fix validation mark for undo and redo over dates

### DIFF
--- a/gulp/DefaultSpecs.js
+++ b/gulp/DefaultSpecs.js
@@ -19,7 +19,7 @@ const constants = {
 
 // Store the default project specifications
 const specs = {
-	version: '2.23.1',
+	version: '2.24.0',
 	name: 'OutSystems DataGrid',
 	description: '',
 	url: 'Website:\n • ' + constants.websiteUrl,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outsystems-datagrid",
-  "version": "2.23.1",
+  "version": "2.24.0",
   "description": "OutSystems Data Grid for Reactive Web",
   "author": "UI Components Team",
   "license": "BSD-3-Clause",

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -158,7 +158,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			// we don't want to redo on GridRemoveRowAction
 			if (
 				action.dataItem !== undefined &&
-				!(typeof action._oldState === 'object' && action._oldState !== null) &&
+				(typeof action._oldState !== 'object' ||
+					action._oldState === null ||
+					action._oldState instanceof Date) &&
 				!(action instanceof GridInsertRowAction) &&
 				!(action instanceof GridRemoveRowAction)
 			) {
@@ -294,8 +296,11 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			// we don't want to undo on GridRemoveRowAction
 			if (
 				action.dataItem !== undefined &&
-				!(typeof action._oldState === 'object' && action._oldState !== null) &&
-				(!(action instanceof GridInsertRowAction) || !(action instanceof GridRemoveRowAction))
+				(typeof action._oldState !== 'object' ||
+					action._oldState === null ||
+					action._oldState instanceof Date) &&
+				!(action instanceof GridInsertRowAction) &&
+				!(action instanceof GridRemoveRowAction)
 			) {
 				const providerColumn = this._grid.provider.getColumn(action.col);
 				const binding = providerColumn.binding;


### PR DESCRIPTION
This PR is for fixing the validation mark for undo and redo over dates

### What was happening
* On Data cells, when an invalid date was selected, followed by a valid date, the undo would not reevaluate for the old value. The inverse behavior was also happening for redo.

### What was done
* The logic was simplified to pass from negations to direct assertion
* A validation for instances of type Date was also included

### Test Steps
1. Open the sample application
2. Select an invalid date (In the Date column, select a day different from today)
3. Select a valid date
4. Do undo
5. Validate that the Invalid marker appears on the cell



### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

